### PR TITLE
Mechanics: Avoid strange freefall behavior by leaving vertical velocity intact when modifying character's rigidbody

### DIFF
--- a/Assets/Code/Controllers/PenguinController.cs
+++ b/Assets/Code/Controllers/PenguinController.cs
@@ -116,7 +116,7 @@ public class PenguinController : MonoBehaviour
                 axis:      penguinRigidBody.transform.forward,
                 angle:     inputRotationAngle);
         }
-        penguinRigidBody.velocity = new Vector2(inputAxes.x * inputMoveSpeed, 0);
+        penguinRigidBody.velocity = new Vector2(inputAxes.x * inputMoveSpeed, penguinRigidBody.velocity.y);
     }
 
     private Vector2 GetSurfaceNormalOfGroundRelativeToPenguin(float maxRayDistance=100.0f)


### PR DESCRIPTION
# Avoid strange freefall behavior by leaving vertical velocity intact when modifying character's rigidbody
Very quick, one liner bug fix.

## Problem
When the penguin leaves the edge of the ground platform, it falls in a strange, 'floaty' way.

## Identified Cause
The vertical velocity is set to zero in fixed update when the input velocity is assigned. This caused strange behavior cause the physics simulation tries to move the rigidbody downwards, but the script then cancels it out, so we get slow, 'floaty' movement.

## Solution
Only horizontal velocity is updated, the previous vertical velocity is kept intact.