### PR TITLE
Camera: First attempt at clamping offsets if they force the camera's subject outside of viewport bounds

### DIFF
--- a/Assets/Code/Controllers/FollowCameraController.cs
+++ b/Assets/Code/Controllers/FollowCameraController.cs
@@ -10,33 +10,34 @@ public class FollowCameraController : MonoBehaviour
     [Header("Game object to follow")]
     [Tooltip("Subject for the camera to move in unison with")]
     [SerializeField] private Transform subject;
+    private Renderer subjectRenderer;
 
-    [Header("Camera offset from subject")]
+    private const float MAX_FOLLOW_DISTANCE = 100;
+    [Header("Follow Settings")]
     [Tooltip("x offset from subject")]
-    [SerializeField] [Range(-30, 30)] private float xOffset = default;
+    [SerializeField] [Range(-MAX_FOLLOW_DISTANCE, MAX_FOLLOW_DISTANCE)] private float xOffset = default;
     [Tooltip("y offset from subject")]
-    [SerializeField] [Range(-30, 30)] private float yOffset = default;
-    float zOffset;
+    [SerializeField] [Range(-MAX_FOLLOW_DISTANCE, MAX_FOLLOW_DISTANCE)] private float yOffset = default;
+    [Tooltip("Prevent subject's sprite renderer from leaving the screen by clamping offsets")]
+    [SerializeField] private bool keepSubjectInScreen = true;
+    [Tooltip("Toggle for actively following")]
+    [SerializeField] private bool isActivelyFollowing = true;
 
-    private Vector3 Offset
+    private Vector3 screenSize;
+    private Vector3 screenMin;
+    private Vector3 screenMax;
+
+    private void Reset()
     {
-        get
-        {
-            return new Vector3(xOffset, yOffset, zOffset);
-        }
+        // forces screensize to update on first update pass
+        screenSize = Vector3.zero;
+        screenMin = Vector3.zero;
+        screenMax = Vector3.zero;
     }
-
-
-    private Vector3 PositionToFollow
-    {
-        get => new Vector3(subject.position.x, subject.position.y, 0);
-    }
-
     void Awake()
     {
         cam = gameObject.GetComponent<Camera>();
-        zOffset = cam.ViewportToWorldPoint(new Vector3(0, 0, cam.nearClipPlane)).z;
-
+        subjectRenderer = gameObject.GetComponent<Renderer>();
         if (!subject)
         {
             Debug.LogWarning($"No subject assigned to follow, `{GetType().Name}` - no object assigned");
@@ -44,9 +45,51 @@ public class FollowCameraController : MonoBehaviour
     }
     void LateUpdate()
     {
-        if (subject != null && subject.transform.hasChanged)
+        if (!isActivelyFollowing)
         {
-            transform.position = PositionToFollow + Offset;
+            return;
+        }
+
+        if (screenSize.x != Screen.width || screenSize.y != Screen.height)
+        {
+            screenSize = new Vector3(Screen.width, Screen.height, 0.00f);
+            screenMin = cam.ViewportToWorldPoint(new Vector3(0.00f, 0.00f, cam.nearClipPlane));
+            screenMax = cam.ViewportToWorldPoint(new Vector3(1.00f, 1.00f, cam.nearClipPlane));
+        }
+
+        if (subject != null)
+        {
+            cam.transform.position = ComputeCameraPosition();
+        }
+    }
+
+    // we don't worry about the case that the subject overlaps multiple sides,
+    // in other words, we assume its bounds are smaller than viewport
+    private Vector3 ComputeCameraPosition()
+    {
+        Vector3 subjectPosition;
+        Vector3 subjectHalfSize;
+        if (subjectRenderer == null)
+        {
+            subjectPosition = subject.position;
+            subjectHalfSize = Vector3.zero;
+        }
+        else
+        {
+            subjectPosition = subjectRenderer.bounds.center;
+            subjectHalfSize = subjectRenderer.bounds.extents;
+        }
+
+        if (keepSubjectInScreen)
+        {
+            return new Vector3(
+                Mathf.Clamp(subjectPosition.x + xOffset, screenMin.x - subjectHalfSize.x, screenMax.x - subjectHalfSize.x),
+                Mathf.Clamp(subjectPosition.y + yOffset, screenMin.y - subjectHalfSize.y, screenMax.y - subjectHalfSize.y),
+                screenMin.z);
+        }
+        else
+        {
+            return new Vector3(subjectPosition.x + xOffset, subjectPosition.y + yOffset, screenMin.z);
         }
     }
 }

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2648,8 +2648,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Solvers:
-  - {fileID: 110818207}
   - {fileID: 696630564}
+  - {fileID: 110818207}
   - {fileID: 751885947}
   - {fileID: 2021943641}
   - {fileID: 1175957789}
@@ -5909,20 +5909,40 @@ PrefabInstance:
       propertyPath: subject
       value: 
       objectReference: {fileID: 27460619}
+    - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: xOffset
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: yOffset
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: keepSubjectInScreen
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: isActivelyFollowing
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 20
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 14.5
+      value: 19.5
       objectReference: {fileID: 0}
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -2.2003174
+      value: -7.30011
       objectReference: {fileID: 0}
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}

--- a/Assets/Sprites/Characters/Penguin/Penguin_Animator.controller
+++ b/Assets/Sprites/Characters/Penguin/Penguin_Animator.controller
@@ -201,31 +201,31 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: YMotionIntensity
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsGrounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 1
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: IsUpright
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 1
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Jump
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Upright


### PR DESCRIPTION
# Clamp offsets if they force the camera's subject outside of followCam's viewport bounds
A step towards more elaborate camera usage (ie panning, stopping/starting, zooming out, etc) - as needed for a deeper platformer experience.

In particular, this PR clamps the offsets to prevent the penguin from fully leaving the screen, and enables toggling of active-following on and off.
![image](https://user-images.githubusercontent.com/8084757/87386678-e8fce000-c555-11ea-9673-dd961df9e958.png)
