### PR TITLE
Camera: Add clamping/smoothing/zooming features to the follow cam

### DIFF
--- a/Assets/Code/Controllers/FollowCameraController.cs
+++ b/Assets/Code/Controllers/FollowCameraController.cs
@@ -1,78 +1,104 @@
 ﻿using UnityEngine;
+using UnityEngine.SocialPlatforms;
 
 
 // todo: look into adding some sort of smoothing when the camera moves
 [ExecuteAlways]
 public class FollowCameraController : MonoBehaviour
 {
+    private const float FOV_DEFAULT    =   50.00f;
+    private const float FOV_MIN        =   10.00f;
+    private const float FOV_MAX        =  100.00f;
+    private const float OFFSET_DEFAULT =    0.00f;
+    private const float OFFSET_MIN     = -100.00f;
+    private const float OFFSET_MAX     =  100.00f;
+    private const float ZOOM_SPEED_DEFAULT =  10.00f;
+    private const float ZOOM_SPEED_MIN     =   0.01f;
+    private const float ZOOM_SPEED_MAX     =  50.00f;
+    private const float MOVE_SPEED_DEFAULT =  10.00f;
+    private const float MOVE_SPEED_MIN     =   0.01f;
+    private const float MOVE_SPEED_MAX     = 100.00f;
+    private const float TARGET_DISTANCE_TOLERANCE = 0.15f;
+
     private Camera cam;
+    private ViewportInfo viewport;
+    public enum FollowMode { MoveWithSubject, MoveAfterLeavingView };
 
-    [Header("Game object to follow")]
-    [Tooltip("Subject for the camera to move in unison with")]
-    [SerializeField] private Transform subject;
-    private Renderer subjectRenderer;
+    [Header("Subject to Follow")]
+    [Tooltip("Transform of subject for camera to follow (does not have to be 'visible')")]
+    [SerializeField]  private Transform subject;
+    [HideInInspector] private Renderer subjectRenderer;
 
-    private const float MAX_FOLLOW_DISTANCE = 100;
-    [Header("Follow Settings")]
-    [Tooltip("x offset from subject")]
-    [SerializeField] [Range(-MAX_FOLLOW_DISTANCE, MAX_FOLLOW_DISTANCE)] private float xOffset = default;
-    [Tooltip("y offset from subject")]
-    [SerializeField] [Range(-MAX_FOLLOW_DISTANCE, MAX_FOLLOW_DISTANCE)] private float yOffset = default;
-    [Tooltip("Prevent subject's sprite renderer from leaving the screen by clamping offsets")]
-    [SerializeField] private bool keepSubjectInScreen = true;
+    [Tooltip("Adjust move speed (how fast the camera follows the subject)")]
+    [Range(MOVE_SPEED_MIN, MOVE_SPEED_MAX)] [SerializeField] private float moveSpeed = MOVE_SPEED_DEFAULT;
+
+    [Header("Follow Position Relative to Subject")]
+    [Tooltip("x offset from subject (subject is on left of camera if positive, right if negative)")]
+    [Range(OFFSET_MIN, OFFSET_MAX)] [SerializeField] private float xOffset = OFFSET_DEFAULT;
+    [Tooltip("y offset from subject (subject is bellow camera if positive, above if negative)")]
+    [Range(OFFSET_MIN, OFFSET_MAX)] [SerializeField] private float yOffset = OFFSET_DEFAULT;
+
+    [Header("Follow Behavior")]
+    [Tooltip("Mode for camera movement relative to to subject")]
+    [SerializeField] private FollowMode followMode = FollowMode.MoveWithSubject;
+    [Tooltip("Clamp offsets to prevent subject's renderer from leaving camera viewport")]
+    [SerializeField] private bool keepSubjectInView = true;
     [Tooltip("Toggle for actively following")]
-    [SerializeField] private bool isActivelyFollowing = true;
+    [SerializeField] private bool isActivelyRunning = true;
 
-    private Vector3 screenSize;
-    private Vector3 screenMin;
-    private Vector3 screenMax;
+    [Header("Zoom Behavior")]
+    [Tooltip("Adjust field of view (how 'zoomed in' the camera is)")]
+    [Range(FOV_MIN, FOV_MAX)] [SerializeField] private float fieldOfView = FOV_DEFAULT;
+    [Tooltip("Adjust zoom speed (how fast the camera FOV is adjusted)")]
+    [Range(ZOOM_SPEED_MIN, ZOOM_SPEED_MAX)] [SerializeField] private float zoomSpeed = ZOOM_SPEED_DEFAULT;
 
-    private void Reset()
-    {
-        // forces screensize to update on first update pass
-        screenSize = Vector3.zero;
-        screenMin = Vector3.zero;
-        screenMax = Vector3.zero;
-    }
     void Awake()
     {
         cam = gameObject.GetComponent<Camera>();
+        Debug.Log("A" + cam);
         subjectRenderer = gameObject.GetComponent<Renderer>();
         if (!subject)
         {
-            Debug.LogWarning($"No subject assigned to follow, `{GetType().Name}` - no object assigned");
+            Debug.LogError($"No subject assigned to follow, `{GetType().Name}` - no object assigned");
         }
+    }
+    void Start()
+    {
+        viewport = new ViewportInfo(cam);
     }
     void LateUpdate()
     {
-        if (!isActivelyFollowing)
+        if (!isActivelyRunning)
         {
             return;
         }
-
-        if (screenSize.x != Screen.width || screenSize.y != Screen.height)
+        bool hasViewportChanged = viewport.SyncChanges();
+        bool hasSubjectChanged  = subject.transform.hasChanged;
+        bool isAtTargetPosition    = Mathf.Abs(fieldOfView - cam.transform.position.x) <= TARGET_DISTANCE_TOLERANCE;
+        bool isAtTargetFieldOfView = Mathf.Abs(fieldOfView - cam.fieldOfView) <= TARGET_DISTANCE_TOLERANCE;
+        if (hasViewportChanged || !isAtTargetFieldOfView)
         {
-            screenSize = new Vector3(Screen.width, Screen.height, 0.00f);
-            screenMin = cam.ViewportToWorldPoint(new Vector3(0.00f, 0.00f, cam.nearClipPlane));
-            screenMax = cam.ViewportToWorldPoint(new Vector3(1.00f, 1.00f, cam.nearClipPlane));
+            Debug.Log("Fov");
+            cam.fieldOfView = Mathf.MoveTowards(cam.fieldOfView, fieldOfView, Time.deltaTime * zoomSpeed);
         }
-
-        if (subject != null)
+        if (hasViewportChanged || !isAtTargetPosition)
         {
-            cam.transform.position = ComputeCameraPosition();
+            Vector2 target = Vector2.MoveTowards(cam.transform.position, ComputeTargetPosition(), Time.deltaTime * moveSpeed);
+            cam.transform.position = new Vector3(target.x, target.y, viewport.NearClipOffset);
+            Debug.Log(cam.transform.position);
         }
     }
 
     // we don't worry about the case that the subject overlaps multiple sides,
     // in other words, we assume its bounds are smaller than viewport
-    private Vector3 ComputeCameraPosition()
+    private Vector2 ComputeTargetPosition()
     {
-        Vector3 subjectPosition;
-        Vector3 subjectHalfSize;
+        Vector2 subjectPosition;
+        Vector2 subjectHalfSize;
         if (subjectRenderer == null)
         {
             subjectPosition = subject.position;
-            subjectHalfSize = Vector3.zero;
+            subjectHalfSize = Vector2.zero;
         }
         else
         {
@@ -80,16 +106,15 @@ public class FollowCameraController : MonoBehaviour
             subjectHalfSize = subjectRenderer.bounds.extents;
         }
 
-        if (keepSubjectInScreen)
+        if (keepSubjectInView)
         {
             return new Vector3(
-                Mathf.Clamp(subjectPosition.x + xOffset, screenMin.x - subjectHalfSize.x, screenMax.x - subjectHalfSize.x),
-                Mathf.Clamp(subjectPosition.y + yOffset, screenMin.y - subjectHalfSize.y, screenMax.y - subjectHalfSize.y),
-                screenMin.z);
+                Mathf.Clamp(subjectPosition.x + xOffset, viewport.Min.x - subjectHalfSize.x, viewport.Max.x - subjectHalfSize.x),
+                Mathf.Clamp(subjectPosition.y + yOffset, viewport.Min.y - subjectHalfSize.y, viewport.Max.y - subjectHalfSize.y));
         }
         else
         {
-            return new Vector3(subjectPosition.x + xOffset, subjectPosition.y + yOffset, screenMin.z);
+            return new Vector2(subjectPosition.x + xOffset, subjectPosition.y + yOffset);
         }
     }
 }

--- a/Assets/Code/Data/ViewportInfo.cs
+++ b/Assets/Code/Data/ViewportInfo.cs
@@ -1,0 +1,48 @@
+﻿using UnityEngine;
+
+
+// provides useful helper methods for given camera object
+// * assumes a single display and eye
+// * all external functionality is in world space coords unless otherwise stated
+public class ViewportInfo
+{
+    private readonly Camera cam;
+
+    private Vector2 _screenSize;
+    private Vector3 _viewportOrigin;
+
+    public Vector2 Min     { get; private set; }
+    public Vector2 Max     { get; private set; }
+    public Vector2 Size    { get; private set; }
+    public Vector2 Extents { get; private set; }
+    public float NearClipOffset { get => _viewportOrigin.z; }
+
+    private void Reset()
+    {
+        // forces screensize to update on first call to `SyncInfo()`
+        _screenSize = Vector2.zero;
+        Min = Vector2.zero;
+        Max = Vector2.zero;
+        SyncChanges();
+    }
+    public ViewportInfo(Camera cam)
+    {
+        this.cam = cam;
+        Reset();
+    }
+
+    public bool SyncChanges()
+    {
+        if (_screenSize.x != Screen.width || _screenSize.y != Screen.height)
+        {
+            _screenSize = new Vector3(Screen.width, Screen.height, 0.00f);
+            _viewportOrigin = cam.ViewportToWorldPoint(new Vector3(0.50f, 0.50f, cam.nearClipPlane));
+            Min = cam.ViewportToWorldPoint(new Vector3(0.00f, 0.00f, cam.nearClipPlane));
+            Max = cam.ViewportToWorldPoint(new Vector3(1.00f, 1.00f, cam.nearClipPlane));
+            Size = Max - Min;
+            Extents = Size * 0.50f;
+            return true;
+        }
+        return false;
+    }
+}

--- a/Assets/Code/Data/ViewportInfo.cs.meta
+++ b/Assets/Code/Data/ViewportInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a095540c96494d942b99161361691dd8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Cameras/FollowCamera.prefab
+++ b/Assets/Prefabs/Cameras/FollowCamera.prefab
@@ -56,12 +56,12 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
+  near clip plane: -30
   far clip plane: 1000
-  field of view: 60
+  field of view: 50
   orthographic: 1
   orthographic size: 50
-  m_Depth: -1
+  m_Depth: -0.97
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
@@ -97,5 +97,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   subject: {fileID: 0}
-  xOffset: 20
-  yOffset: 15
+  moveSpeed: 10
+  xOffset: 0
+  yOffset: 0
+  followMode: 0
+  keepSubjectInView: 1
+  isActivelyRunning: 1
+  fieldOfView: 50
+  zoomSpeed: 10

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -5912,12 +5912,12 @@ PrefabInstance:
     - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: xOffset
-      value: 50
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: yOffset
-      value: 20
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
@@ -5932,17 +5932,17 @@ PrefabInstance:
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 50
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 19.5
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -7.30011
+      value: -5.800171
       objectReference: {fileID: 0}
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -3129,7 +3129,7 @@ MonoBehaviour:
     - {x: 0, y: 0, z: 0.1326581, w: 0.9911619}
     - {x: 0, y: 0, z: -0.4310487, w: 0.9023287}
     - {x: 0, y: 0, z: -0.458195, w: 0.8888517}
-    - {x: 0, y: 0, z: -0.00000023841847, w: 1}
+    - {x: -1e-45, y: 1e-45, z: -0.00000023841847, w: 1}
   m_Iterations: 15
   m_Tolerance: 0.01
   m_Velocity: 0.5
@@ -3609,7 +3609,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 751676750}
-  m_LocalRotation: {x: 0, y: 0, z: -0.000000026077032, w: 1}
+  m_LocalRotation: {x: -3e-45, y: 3e-45, z: -0.000000026077032, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -3680,7 +3680,7 @@ MonoBehaviour:
     m_StoredLocalRotations:
     - {x: 0, y: 0, z: 0.005699533, w: 0.9999838}
     - {x: 0, y: 0, z: -0.037286036, w: 0.99930465}
-    - {x: 0, y: 0, z: -0.000000026077032, w: 1}
+    - {x: -3e-45, y: 3e-45, z: -0.000000026077032, w: 1}
   m_Iterations: 15
   m_Tolerance: 0.01
   m_Velocity: 0.5
@@ -4254,7 +4254,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1272653199}
-  m_LocalRotation: {x: 0, y: 0, z: -0.00000023841847, w: 1}
+  m_LocalRotation: {x: -1e-45, y: 1e-45, z: -0.00000023841847, w: 1}
   m_LocalPosition: {x: 5.22, y: 0.88, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -5911,16 +5911,6 @@ PrefabInstance:
       objectReference: {fileID: 27460619}
     - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
-      propertyPath: xOffset
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
-        type: 3}
-      propertyPath: yOffset
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3122338546308357070, guid: 4ea485da32399be4ebfab01cef57f2eb,
-        type: 3}
       propertyPath: keepSubjectInScreen
       value: 1
       objectReference: {fileID: 0}
@@ -5942,7 +5932,7 @@ PrefabInstance:
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -5.800171
+      value: -12.880005
       objectReference: {fileID: 0}
     - target: {fileID: 7110129387180373541, guid: 4ea485da32399be4ebfab01cef57f2eb,
         type: 3}
@@ -5988,6 +5978,56 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: FollowCamera
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: near clip plane
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: m_BackGroundColor.r
+      value: 0.39215687
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: m_BackGroundColor.g
+      value: 0.6862745
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: m_BackGroundColor.b
+      value: 0.98039216
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: m_BackGroundColor.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: field of view
+      value: 120.80029
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: orthographic
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: orthographic size
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: m_Depth
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7110129387180373722, guid: 4ea485da32399be4ebfab01cef57f2eb,
+        type: 3}
+      propertyPath: m_TargetEye
+      value: 3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4ea485da32399be4ebfab01cef57f2eb, type: 3}


### PR DESCRIPTION
# Add proper clamping/smoothing/zooming features to the follow cam
Taking a short break from animations, and took the time to make the camera more customizable as a stepping stone to the up and coming parallax and respawning mechanics that will be needed.

* Change default offsets
* Add clamping (ie keeping the camera from moving outside the view of the penguin)/smoothing/zoom/target tolerance filtering, and viewport meta data, all of which can be modified in inspector for an improved camera experience, see the left side in the below image for an idea on what can be controlled in the camera now

![followCamera-showcase](https://user-images.githubusercontent.com/8084757/87499008-11481580-c60e-11ea-9c1a-370c7e3e5fa2.png)
