### PR TITLE
Mechanics: Enhance ground checking for penguin

### DIFF
--- a/Assets/Code/Controllers/PenguinController.cs
+++ b/Assets/Code/Controllers/PenguinController.cs
@@ -43,11 +43,6 @@ public class PenguinController : MonoBehaviour
     [SerializeField] [Range(JUMP_FORCE_MIN, JUMP_FORCE_MAX)]
     private float jumpForce = JUMP_FORCE_DEFAULT;
 
-    [Header("Misc Settings")]
-    [Tooltip("Reference to the bottom-most root joint of the penguin skeletal model")]
-    [SerializeField]
-    private Transform skeletalRoot = default;
-
     private Vector3 PenguinScale
     {
         get => penguinRigidBody.transform.localScale;
@@ -80,6 +75,7 @@ public class PenguinController : MonoBehaviour
         Standup();
         TurnToFace(Facing.RIGHT);
         groundChecker.Reset();
+        penguinAnimator.applyRootMotion = true;
         UpdateAnimatorParameters();
     }
     void OnEnable()
@@ -103,7 +99,7 @@ public class PenguinController : MonoBehaviour
 
     void Update()
     {
-        groundChecker.CheckForGround(fromPoint: skeletalRoot.position,
+        groundChecker.CheckForGround(fromPoint: penguinAnimator.rootPosition,
                                      extraLineHeight: penguinCollider.bounds.extents.y);
 
         Vector2 inputAxes = MovementRequested;

--- a/Assets/Code/Controllers/PenguinController.cs
+++ b/Assets/Code/Controllers/PenguinController.cs
@@ -1,45 +1,63 @@
 ﻿using UnityEngine;
+using UnityEngine.Experimental.U2D.Animation;
 using UnityEngine.InputSystem;
 
 
-// todo: look into a way to use enums directly in animator (perhaps via passing int and using editor script, etc?)
+[RequireComponent(typeof(Rigidbody2D))]
+[RequireComponent(typeof(BoxCollider2D))]
+[RequireComponent(typeof(Animator))]
+[RequireComponent(typeof(SpriteLibrary))]
 [RequireComponent(typeof(PlayerInput))]
+[RequireComponent(typeof(GroundChecker))]
 public class PenguinController : MonoBehaviour
 {
-    private bool isGrounded;
+    private const float STATE_TRANSITION_SPEED_DEFAULT = 0.10f;
+    private const float STATE_TRANSITION_SPEED_MIN     = 0.10f;
+    private const float STATE_TRANSITION_SPEED_MAX     = 1.00f;
+    private const float JUMP_FORCE_DEFAULT =  50000.00f;
+    private const float JUMP_FORCE_MIN     =  25000.00f;
+    private const float JUMP_FORCE_MAX     = 250000.00f;
+
+    private Vector2 initialSpawnPosition;
+    private Animator penguinAnimator;
+    private Rigidbody2D penguinRigidBody;
+    private BoxCollider2D penguinCollider;
+    private PlayerControls playerControls;
+    private GroundChecker groundChecker;
+
     private float xMotionIntensity;
     private Facing facing;
     private Posture posture;
     private enum Facing  { LEFT,    RIGHT   }
     private enum Posture { UPRIGHT, ONBELLY }
 
-    [Header("Movement")]
+    [Header("Animation Settings")]
     [Tooltip("Amount of progress made per frame when transitioning between states " +
              "(ie 0.05 for a blended delayed transition taking at least 20 frames," +
              "1.00 for an instant transition with no blending)")]
-    [SerializeField] [Range(0.01f, 1.00f)] private float stateTransitionSpeed = 0.10f;
+    [SerializeField] [Range(STATE_TRANSITION_SPEED_MIN, STATE_TRANSITION_SPEED_MAX)]
+    private float stateTransitionSpeed = STATE_TRANSITION_SPEED_DEFAULT;
 
-    [Header("Input Configuration")]
-    private PlayerControls playerControls;
+    [Header("Jump Settings")]
+    [Tooltip("Jump force in newtons")]
+    [SerializeField] [Range(JUMP_FORCE_MIN, JUMP_FORCE_MAX)]
+    private float jumpForce = JUMP_FORCE_DEFAULT;
 
-    private Vector2 initialSpawnPosition;
-    private Animator penguinAnimator;
-    private Rigidbody2D penguinRigidBody;
-    private BoxCollider2D penguinCollider;
-
-    private Vector3 PenguinCenter
-    {
-        get => penguinCollider.bounds.center;
-    }
     private Vector3 PenguinScale
     {
         get => penguinRigidBody.transform.localScale;
         set => penguinRigidBody.transform.localScale = value;
     }
+    // todo: incorporate object references for fire/use request (ie what object is being used?)
+    private bool    IsFireRequested    => playerControls.Gameplay.Fire.triggered;
+    private bool    IsUseItemRequested => playerControls.Gameplay.Use.triggered;
+    private Vector2 MovementRequested  => playerControls.Gameplay.Move.ReadValue<Vector2>();
+
+    // update all animator parameters (except for triggers, as those should be set directly)
     private void UpdateAnimatorParameters()
     {
         // ideally we would use the enums directly, but enum is not a supported parameter type for animator
-        penguinAnimator.SetBool("IsGrounded", isGrounded);
+        penguinAnimator.SetBool("IsGrounded", groundChecker.WasDetected);
         penguinAnimator.SetBool("IsUpright",  posture == Posture.UPRIGHT);
         penguinAnimator.SetFloat("XMotionIntensity", xMotionIntensity);
     }
@@ -50,13 +68,13 @@ public class PenguinController : MonoBehaviour
         penguinRigidBody.velocity = Vector2.zero;
         penguinRigidBody.position = initialSpawnPosition;
 
-        isGrounded = true;
         xMotionIntensity = 0.00f;
         penguinAnimator.updateMode = AnimatorUpdateMode.AnimatePhysics;
         penguinAnimator.applyRootMotion = true;
 
         Standup();
         TurnToFace(Facing.RIGHT);
+        groundChecker.CheckForGround();
         UpdateAnimatorParameters();
     }
     void OnEnable()
@@ -70,32 +88,18 @@ public class PenguinController : MonoBehaviour
     void Awake()
     {
         playerControls = new PlayerControls();
-
         penguinRigidBody = gameObject.GetComponent<Rigidbody2D>();
         penguinCollider  = gameObject.GetComponent<BoxCollider2D>();
         penguinAnimator  = gameObject.GetComponent<Animator>();
-
+        groundChecker    = gameObject.GetComponent<GroundChecker>();
         initialSpawnPosition = penguinRigidBody.position;
         Reset();
     }
 
-    // todo: incorporate object references for fire/use request (ie what object is being used?)
-    private bool IsFireRequested
-    {
-        get => playerControls.Gameplay.Fire.triggered;
-    }
-    private bool IsUseItemRequested
-    {
-        get => playerControls.Gameplay.Use.triggered;
-    }
-    private Vector2 MovementRequested
-    {
-        get => playerControls.Gameplay.Move.ReadValue<Vector2>();
-    }
-
     void Update()
     {
-        GroundCheck();
+        groundChecker.CheckForGround();
+        Debug.Log(groundChecker);
         Vector2 inputAxes = MovementRequested;
 
         if (Mathf.Approximately(inputAxes.x, 0.00f))
@@ -108,15 +112,15 @@ public class PenguinController : MonoBehaviour
             TurnToFace(inputAxes.x < 0 ? Facing.LEFT : Facing.RIGHT);
         }
 
-        if (inputAxes.y < 0.00f && isGrounded && posture == Posture.UPRIGHT)
+        if (inputAxes.y < 0.00f && groundChecker.WasDetected && posture == Posture.UPRIGHT)
         {
             LieDown();
         }
-        else if (inputAxes.y > 0.00f && isGrounded && posture == Posture.UPRIGHT)
+        else if (inputAxes.y > 0.00f && groundChecker.WasDetected && posture == Posture.UPRIGHT)
         {
             Jump();
         }
-        else if (inputAxes.y > 0.00f && isGrounded && posture == Posture.ONBELLY)
+        else if (inputAxes.y > 0.00f && groundChecker.WasDetected && posture == Posture.ONBELLY)
         {
             Standup();
         }
@@ -131,12 +135,6 @@ public class PenguinController : MonoBehaviour
         }
 
         UpdateAnimatorParameters();
-    }
-
-    private void GroundCheck()
-    {
-        // todo: add proper raycasting against platform layers
-        isGrounded = Physics2D.Raycast(transform.position + (Vector3.up * 0.1f), Vector3.down, 0.30f, LayerMask.GetMask("Platform"));
     }
 
     private void TurnToFace(Facing facing)
@@ -167,7 +165,6 @@ public class PenguinController : MonoBehaviour
     private void Jump()
     {
         Debug.Log("Jump!");
-        float jumpForce = 50000.00f;
         penguinRigidBody.AddForce(Vector3.up * jumpForce, ForceMode2D.Impulse);
         penguinAnimator.SetTrigger("Jump");
     }

--- a/Assets/Code/Controllers/PenguinController.cs
+++ b/Assets/Code/Controllers/PenguinController.cs
@@ -43,6 +43,11 @@ public class PenguinController : MonoBehaviour
     [SerializeField] [Range(JUMP_FORCE_MIN, JUMP_FORCE_MAX)]
     private float jumpForce = JUMP_FORCE_DEFAULT;
 
+    [Header("Misc Settings")]
+    [Tooltip("Reference to the bottom-most root joint of the penguin skeletal model")]
+    [SerializeField]
+    private Transform skeletalRoot = default;
+
     private Vector3 PenguinScale
     {
         get => penguinRigidBody.transform.localScale;
@@ -74,7 +79,7 @@ public class PenguinController : MonoBehaviour
 
         Standup();
         TurnToFace(Facing.RIGHT);
-        groundChecker.CheckForGround();
+        groundChecker.Reset();
         UpdateAnimatorParameters();
     }
     void OnEnable()
@@ -98,10 +103,10 @@ public class PenguinController : MonoBehaviour
 
     void Update()
     {
-        groundChecker.CheckForGround();
-        Debug.Log(groundChecker);
-        Vector2 inputAxes = MovementRequested;
+        groundChecker.CheckForGround(fromPoint: skeletalRoot.position,
+                                     extraLineHeight: penguinCollider.bounds.extents.y);
 
+        Vector2 inputAxes = MovementRequested;
         if (Mathf.Approximately(inputAxes.x, 0.00f))
         {
             xMotionIntensity = Mathf.Clamp01(xMotionIntensity - (stateTransitionSpeed));

--- a/Assets/Code/Data/GroundChecker.cs
+++ b/Assets/Code/Data/GroundChecker.cs
@@ -1,0 +1,106 @@
+﻿using UnityEngine;
+
+
+// todo: might be better to configure this using a variable offset and collider
+// provides functionality for checking if 'ground' is below given collider
+//
+// features:
+// * ray and object to check from are configured via inspector and tracked by the checker
+// * reassigns result each time the check function is invoked, null if ground was not detected
+//
+// notes:
+// * all the queries and info reflect the results of the ground check, as last updated
+// * assumes that the project's physics settings are configured such that the raycast
+//   doesn't trigger the collider it starts in (otherwise, casting from inside ground layer will fail to get a result)
+[System.Serializable]
+[AddComponentMenu("GroundChecker")]
+public class GroundChecker : MonoBehaviour
+{
+    public struct Contact
+    {
+        public Vector2 rayOrigin;
+        public Vector2 point;
+        public Vector2 normal;
+        public float distance;
+        public Contact(Vector2 rayOrigin, Vector2 point, Vector2 normal, float distance)
+        {
+            this.rayOrigin = rayOrigin;
+            this.point = point;
+            this.normal = normal;
+            this.distance = distance;
+        }
+    }
+
+    public Contact Result         { get; private set; }
+    public bool WasDetected       { get; private set; }
+    public float MaxRayDistance   { get; private set; }
+    public Vector2 SourcePosition { get => source.TransformVector(source.position); }
+
+    private readonly Color RAY_DEBUG_DRAW_COLOR = Color.green;
+    private const float TOLERANCE_DEFAULT = 0.30f;
+    private const float TOLERANCE_MIN = 0.05f;
+    private const float TOLERANCE_MAX = 10.00f;
+    public static readonly Vector2 RAY_DIRECTION = Vector2.down;
+
+    [Header("Raycast Settings")]
+    [Tooltip("Object to raycast from (ie skeletal model's root joint)")]
+    [SerializeField] private Transform source;
+    [Tooltip("Offset from raycast source (ie (0, 2) will cast from y=2 above source)")]
+    [SerializeField] private Vector2 offset;
+
+    [Tooltip("What do we consider to be 'ground'?")]
+    [SerializeField] private LayerMask groundMask = default;
+
+    [Tooltip("How close does it need to be to be considered touching? " +
+            "(this determines the max length of the raycast used for performing the ground check)")]
+    [SerializeField] [Range(TOLERANCE_MIN, TOLERANCE_MAX)]
+    private float toleratedDistance = TOLERANCE_DEFAULT;
+
+    [Tooltip("Draw raycasts in scene view for debugging purposes")]
+    [SerializeField] private bool showRaycastsInSceneView = true;
+
+    public override string ToString()
+    {
+        if (WasDetected)
+        {
+            return $"Ground detected from source position{Result.rayOrigin} {Result.distance} units " +
+                   $"below source object (at point {Result.point} with normal of {Result.normal}";
+        }
+        return $"No ground detected from source position{Result.rayOrigin}";
+    }
+
+    #if UNITY_EDITOR
+    void OnValidate()
+    {
+        MaxRayDistance = offset.magnitude + toleratedDistance;
+        if (offset.y < 0.00f)
+        {
+            Debug.LogWarning("Negative y offsets may cause a raycast to start from the target ground layer, " +
+                             "and thus possibly fail to properly detect ground");
+        }
+    }
+    #endif
+
+    void Awake()
+    {
+        Result = default;
+        WasDetected = false;
+        MaxRayDistance = offset.magnitude + toleratedDistance;
+    }
+
+    // check for ground below the our source object
+    public void CheckForGround()
+    {
+        Vector2 origin = SourcePosition + offset;
+        RaycastHit2D hitInfo = Physics2D.Raycast(origin, RAY_DIRECTION, MaxRayDistance, groundMask);
+
+        WasDetected = hitInfo;
+        Result = WasDetected ? new Contact(origin, hitInfo.centroid, hitInfo.normal, hitInfo.distance) : default;
+        #if UNITY_EDITOR
+        if (showRaycastsInSceneView)
+        {
+            Debug.DrawLine(origin, Result.point, RAY_DEBUG_DRAW_COLOR, Time.deltaTime);
+        }
+        #endif
+    }
+}

--- a/Assets/Code/Data/GroundChecker.cs
+++ b/Assets/Code/Data/GroundChecker.cs
@@ -1,12 +1,12 @@
 ﻿using UnityEngine;
 
 
-// todo: might be better to configure this using a variable offset and collider
-// provides functionality for checking if 'ground' is below given collider
+// provides functionality for checking if 'ground' is directly below given point
 //
 // features:
 // * ray and object to check from are configured via inspector and tracked by the checker
 // * reassigns result each time the check function is invoked, null if ground was not detected
+// * vertical offsets (from source) can be set programmatically
 //
 // notes:
 // * all the queries and info reflect the results of the ground check, as last updated
@@ -18,88 +18,99 @@ public class GroundChecker : MonoBehaviour
 {
     public struct Contact
     {
-        public Vector2 rayOrigin;
         public Vector2 point;
         public Vector2 normal;
         public float distance;
-        public Contact(Vector2 rayOrigin, Vector2 point, Vector2 normal, float distance)
+        public Contact(Vector2 point, Vector2 normal, float distance)
         {
-            this.rayOrigin = rayOrigin;
-            this.point = point;
-            this.normal = normal;
+            this.point    = point;
+            this.normal   = normal;
             this.distance = distance;
         }
     }
 
-    public Contact Result         { get; private set; }
-    public bool WasDetected       { get; private set; }
-    public float MaxRayDistance   { get; private set; }
-    public Vector2 SourcePosition { get => source.TransformVector(source.position); }
+    private const float TOLERANCE_DEFAULT =  0.30f;
+    private const float TOLERANCE_MIN     =  0.05f;
+    private const float TOLERANCE_MAX     = 10.00f;
+    private static readonly Color RAY_HIT_COLOR_DEFAULT  = Color.green;
+    private static readonly Color RAY_MISS_COLOR_DEFAULT = Color.red;
 
-    private readonly Color RAY_DEBUG_DRAW_COLOR = Color.green;
-    private const float TOLERANCE_DEFAULT = 0.30f;
-    private const float TOLERANCE_MIN = 0.05f;
-    private const float TOLERANCE_MAX = 10.00f;
-    public static readonly Vector2 RAY_DIRECTION = Vector2.down;
-
-    [Header("Raycast Settings")]
-    [Tooltip("Object to raycast from (ie skeletal model's root joint)")]
-    [SerializeField] private Transform source;
-    [Tooltip("Offset from raycast source (ie (0, 2) will cast from y=2 above source)")]
-    [SerializeField] private Vector2 offset;
+    private Vector2 origin;
+    private float extraLineHeight;
+    public Contact Result       { get; private set; }
+    public bool WasDetected     { get; private set; }
 
     [Tooltip("What do we consider to be 'ground'?")]
     [SerializeField] private LayerMask groundMask = default;
 
     [Tooltip("How close does it need to be to be considered touching? " +
-            "(this determines the max length of the raycast used for performing the ground check)")]
+             "(this determines the max length of the raycast used for performing the ground check)")]
     [SerializeField] [Range(TOLERANCE_MIN, TOLERANCE_MAX)]
-    private float toleratedDistance = TOLERANCE_DEFAULT;
+    private float toleratedHeightFromGround = TOLERANCE_DEFAULT;
 
+    [Header("Debug Settings")]
     [Tooltip("Draw raycasts in scene view for debugging purposes")]
     [SerializeField] private bool showRaycastsInSceneView = true;
 
+    [Tooltip("Color of ray to draw if enabled and detected ground")]
+    [SerializeField] private Color rayColorIfHit = RAY_HIT_COLOR_DEFAULT;
+
+    [Tooltip("Color of ray to draw if enabled and didn't detect ground")]
+    [SerializeField] private Color rayColorIfMiss = RAY_MISS_COLOR_DEFAULT;
+
     public override string ToString()
     {
+        Vector2 givenPoint = new Vector2(origin.x, origin.y - extraLineHeight);
         if (WasDetected)
         {
-            return $"Ground detected from source position{Result.rayOrigin} {Result.distance} units " +
-                   $"below source object (at point {Result.point} with normal of {Result.normal}";
+            return $"Ground detected from source position{givenPoint} {Result.distance} units " +
+                   $"below source object (at point {Result.point} with normal of {Result.normal}, " +
+                   $"using an origin yOffset of {extraLineHeight}";
         }
-        return $"No ground detected from source position{Result.rayOrigin}";
+        return $"No ground detected from source position{origin} " +
+               $"using an origin yOffset of {extraLineHeight}";
     }
 
-    #if UNITY_EDITOR
-    void OnValidate()
-    {
-        MaxRayDistance = offset.magnitude + toleratedDistance;
-        if (offset.y < 0.00f)
-        {
-            Debug.LogWarning("Negative y offsets may cause a raycast to start from the target ground layer, " +
-                             "and thus possibly fail to properly detect ground");
-        }
-    }
-    #endif
-
-    void Awake()
+    public void Reset()
     {
         Result = default;
         WasDetected = false;
-        MaxRayDistance = offset.magnitude + toleratedDistance;
+    }
+    void Awake()
+    {
+        Reset();
     }
 
-    // check for ground below the our source object
-    public void CheckForGround()
+    // check for ground below the our source object,
+    // with some extra line height to ensure it starts just above our targeted layer if given
+    public void CheckForGround(Vector2 fromPoint, float extraLineHeight=0.00f)
     {
-        Vector2 origin = SourcePosition + offset;
-        RaycastHit2D hitInfo = Physics2D.Raycast(origin, RAY_DIRECTION, MaxRayDistance, groundMask);
+        this.extraLineHeight = extraLineHeight;
+        origin           = new Vector2(fromPoint.x, fromPoint.y + extraLineHeight);
+        Vector2 terminal = new Vector2(fromPoint.x, fromPoint.y - toleratedHeightFromGround);
 
-        WasDetected = hitInfo;
-        Result = WasDetected ? new Contact(origin, hitInfo.centroid, hitInfo.normal, hitInfo.distance) : default;
-        #if UNITY_EDITOR
-        if (showRaycastsInSceneView)
+        Debug.Log($"from {origin} to {terminal}");
+        RaycastHit2D hitInfo = Physics2D.Linecast(origin, terminal, groundMask);
+        if (hitInfo && (hitInfo.distance - extraLineHeight) < toleratedHeightFromGround)
         {
-            Debug.DrawLine(origin, Result.point, RAY_DEBUG_DRAW_COLOR, Time.deltaTime);
+            WasDetected = true;
+            Result = new Contact(hitInfo.centroid, hitInfo.normal, hitInfo.distance - extraLineHeight);
+        }
+        else
+        {
+            WasDetected = false;
+            Result = default;
+        }
+
+        Debug.Log(this);
+        #if UNITY_EDITOR
+        if (showRaycastsInSceneView && WasDetected)
+        {
+            Debug.DrawLine(origin, Result.point, rayColorIfHit, Time.deltaTime);
+        }
+        if (showRaycastsInSceneView && !WasDetected)
+        {
+            Debug.DrawLine(origin, origin - new Vector2(0, toleratedHeightFromGround), rayColorIfMiss, Time.deltaTime);
         }
         #endif
     }

--- a/Assets/Code/Data/GroundChecker.cs.meta
+++ b/Assets/Code/Data/GroundChecker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c7ff032402c77c4e963e4b105b29d85
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2635,7 +2635,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   stateTransitionSpeed: 0.1
-  jumpForce: 25000
+  jumpForce: 50000
+  skeletalRoot: {fileID: 1725026792}
 --- !u!114 &27460629
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2934,13 +2935,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6c7ff032402c77c4e963e4b105b29d85, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  source: {fileID: 1725026792}
-  offset: {x: 0, y: 1}
   groundMask:
     serializedVersion: 2
     m_Bits: 256
-  toleratedDistance: 0.3
+  toleratedHeightFromGround: 0.3
   showRaycastsInSceneView: 1
+  rayColorIfHit: {r: 0, g: 1, b: 0, a: 1}
+  rayColorIfMiss: {r: 1, g: 0, b: 0, a: 1}
 --- !u!1 &52369770
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2635,6 +2635,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   stateTransitionSpeed: 0.1
+  jumpForce: 25000
 --- !u!114 &27460629
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2921,6 +2922,25 @@ MonoBehaviour:
   m_DefaultActionMap: Gameplay
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!114 &27460654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 27460624}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6c7ff032402c77c4e963e4b105b29d85, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 1725026792}
+  offset: {x: 0, y: 1}
+  groundMask:
+    serializedVersion: 2
+    m_Bits: 256
+  toleratedDistance: 0.3
+  showRaycastsInSceneView: 1
 --- !u!1 &52369770
 GameObject:
   m_ObjectHideFlags: 0
@@ -5738,6 +5758,12 @@ MonoBehaviour:
   m_Iterations: 15
   m_Tolerance: 0.01
   m_Velocity: 0.5
+--- !u!4 &1725026792 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -388933118533720201, guid: c9587e548613a564c81ba23ebf263460,
+    type: 3}
+  m_PrefabInstance: {fileID: 27460618}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1751776878
 GameObject:
   m_ObjectHideFlags: 0
@@ -6227,7 +6253,7 @@ MonoBehaviour:
   keepSubjectInView: 1
   isActivelyRunning: 1
   maxMoveSpeed: 250
-  fieldOfView: 50
+  orthographicSize: 50
   maxZoomSpeed: 10
 --- !u!4 &6127185479514728925 stripped
 Transform:

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2636,7 +2636,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   stateTransitionSpeed: 0.1
   jumpForce: 50000
-  skeletalRoot: {fileID: 1725026792}
 --- !u!114 &27460629
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2939,9 +2938,10 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 256
   toleratedHeightFromGround: 0.3
-  showRaycastsInSceneView: 1
-  rayColorIfHit: {r: 0, g: 1, b: 0, a: 1}
-  rayColorIfMiss: {r: 1, g: 0, b: 0, a: 1}
+  displayVisualAids: 1
+  rayColorTop: {r: 0, g: 0.2924528, b: 0.2924528, a: 1}
+  rayColorLower: {r: 0, g: 0, b: 1, a: 1}
+  rayColorBottom: {r: 0, g: 1, b: 0, a: 1}
 --- !u!1 &52369770
 GameObject:
   m_ObjectHideFlags: 0
@@ -5759,12 +5759,6 @@ MonoBehaviour:
   m_Iterations: 15
   m_Tolerance: 0.01
   m_Velocity: 0.5
---- !u!4 &1725026792 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: -388933118533720201, guid: c9587e548613a564c81ba23ebf263460,
-    type: 3}
-  m_PrefabInstance: {fileID: 27460618}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1751776878
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -40,7 +40,7 @@ Physics2DSettings:
     m_IslandSolverContactsPerJob: 50
   m_AutoSimulation: 1
   m_QueriesHitTriggers: 1
-  m_QueriesStartInColliders: 1
+  m_QueriesStartInColliders: 0
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 1
   m_AutoSyncTransforms: 0
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: c8f8ffffc8f8ffffc8f8ffffffffffffc8f8ffffc8f8ffffffffffffffffffffc8fbffffc8fbffffc8f8ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
# Enhance ground checking for penguin
This pr is a step towards the sliding and jumping animations working properly, as they do ground checking relative to the animator root, rather than the center of the collider. This is important, since it means that now, it does not matter where the collider is (all though we do offset the origin of the raycasts above the root to avoid the cast starting in the ground layer and thus failing to detect the ground)...

Which means that as long as the penguin's root doesn't change its relative position - then the rotation of the collider (which note - need to have that somehow rotate in unison with the bones!) won't change the fact that the ground check is always being done from the bottom middle of the penguin.

The custom component (and visual debugging raycasts - yeah I know its hard to see with all the joints around it..) can be seen below:
![image](https://user-images.githubusercontent.com/8084757/88440207-25d09e80-cdc2-11ea-941d-c8485663d477.png)
