### PR TITLE
Custom PropertyDrawers: Tag selection and readonly

### DIFF
--- a/Assets/Code/Editor/ReadOnlyFieldPropertyDrawer.cs
+++ b/Assets/Code/Editor/ReadOnlyFieldPropertyDrawer.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+
+[CustomPropertyDrawer(typeof(ReadOnlyFieldAttribute))]
+public class ReadOnlyFieldPropertyDrawer : PropertyDrawer
+{
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property, label, true);
+    }
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        using (var scope = new EditorGUI.DisabledGroupScope(true))
+        {
+            EditorGUI.PropertyField(position, property, label, includeChildren: true);
+        }
+    }
+}

--- a/Assets/Code/Editor/ReadOnlyFieldPropertyDrawer.cs.meta
+++ b/Assets/Code/Editor/ReadOnlyFieldPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e65bea64bf1d8484baab92388d896877
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/Editor/TagSelectorPropertyDrawer.cs
+++ b/Assets/Code/Editor/TagSelectorPropertyDrawer.cs
@@ -3,47 +3,55 @@ using UnityEditor;
 using System;
 
 
-// adopted from: http://www.brechtos.com/tagselectorattribute/
 [CustomPropertyDrawer(typeof(TagSelectorAttribute))]
 public class TagSelectorPropertyDrawer : PropertyDrawer
 {
-    private string[] tags;
-    private const string EMPTY_TAG_NAME = "<No Tag>";
-
-    private void UpdateTags()
+    internal static class Tags
     {
-        tags = CollectionUtils.PrependToArray(EMPTY_TAG_NAME, UnityEditorInternal.InternalEditorUtility.tags);
-    }
+        private static string[] _cachedTags;
+        public static string[] tags;
+        public static GUIContent[] DisplayContents { get; private set; }
+        public const string EMPTY_TAG = "";
+        public const string EMPTY_TAG_DISPLAY_NAME = "<No Tag>";
 
-    private int IndexOfTag(string tag)
-    {
-        return tag == "" ? 0 : Array.IndexOf(tags, tag, 1);
+        static Tags()
+        {
+            Update();
+        }
+        public static string Select(int index)
+        {
+            return index <= 0 ? EMPTY_TAG : _cachedTags[index];
+        }
+        public static int IndexOf(string tag)
+        {
+            return tag == EMPTY_TAG ? 0 : Array.IndexOf(_cachedTags, tag, 1);
+        }
+        public static void Update()
+        {
+            if (CollectionUtils.AreElementsEqual(_cachedTags, UnityEditorInternal.InternalEditorUtility.tags))
+            {
+                return;
+            }
+            _cachedTags = UnityEditorInternal.InternalEditorUtility.tags;
+            tags = CollectionUtils.PrependToArray(EMPTY_TAG_DISPLAY_NAME, UnityEditorInternal.InternalEditorUtility.tags);
+        }
     }
 
     // get the latest tags from editor and display them in a dropdown with our drawer getting the selected tag
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
     {
-        if (property.propertyType == SerializedPropertyType.String)
-        {
-            EditorGUI.BeginProperty(position, label, property);
-
-            var attrib = this.attribute as TagSelectorAttribute;
-            if (attrib.UseDefaultTagFieldDrawer)
-            {
-                property.stringValue = EditorGUI.TagField(position, label, property.stringValue);
-            }
-            else
-            {
-                UpdateTags();
-                int selectedIndex = EditorGUI.Popup(position, label.text, IndexOfTag(property.stringValue), displayedOptions: tags);
-                property.stringValue = selectedIndex >= 1? tags[selectedIndex] : "";
-            }
-
-            EditorGUI.EndProperty();
-        }
-        else
+        if (property.propertyType != SerializedPropertyType.String)
         {
             EditorGUI.PropertyField(position, property, label);
+            return;
+        }
+
+        using (var scope = new EditorGUI.PropertyScope(position, label, property))
+        {
+            Tags.Update();
+            Debug.Log(Tags.IndexOf(property.stringValue));
+            property.stringValue = Tags.Select(
+                EditorGUI.Popup(position, label.text, Tags.IndexOf(property.stringValue), Tags.tags));
         }
     }
 }

--- a/Assets/Code/Editor/TagSelectorPropertyDrawer.cs
+++ b/Assets/Code/Editor/TagSelectorPropertyDrawer.cs
@@ -8,9 +8,7 @@ public class TagSelectorPropertyDrawer : PropertyDrawer
 {
     internal static class Tags
     {
-        private static string[] _cachedTags;
-        public static string[] tags;
-        public static GUIContent[] DisplayContents { get; private set; }
+        public static string[] DisplayNames { get; private set; }
         public const string EMPTY_TAG = "";
         public const string EMPTY_TAG_DISPLAY_NAME = "<No Tag>";
 
@@ -20,20 +18,19 @@ public class TagSelectorPropertyDrawer : PropertyDrawer
         }
         public static string Select(int index)
         {
-            return index <= 0 ? EMPTY_TAG : _cachedTags[index];
+            return index <= 0 ? EMPTY_TAG : DisplayNames[index];
         }
         public static int IndexOf(string tag)
         {
-            return tag == EMPTY_TAG ? 0 : Array.IndexOf(_cachedTags, tag, 1);
+            return tag == EMPTY_TAG ? 0 : Array.IndexOf(DisplayNames, tag, 1);
         }
         public static void Update()
         {
-            if (CollectionUtils.AreElementsEqual(_cachedTags, UnityEditorInternal.InternalEditorUtility.tags))
+            var newTags = UnityEditorInternal.InternalEditorUtility.tags;
+            if (!CollectionUtils.AreArraySegmentsEqual(newTags, DisplayNames, start1: 0, start2: 1))
             {
-                return;
+                DisplayNames = CollectionUtils.PrependToArray(EMPTY_TAG_DISPLAY_NAME, newTags);
             }
-            _cachedTags = UnityEditorInternal.InternalEditorUtility.tags;
-            tags = CollectionUtils.PrependToArray(EMPTY_TAG_DISPLAY_NAME, UnityEditorInternal.InternalEditorUtility.tags);
         }
     }
 
@@ -49,9 +46,8 @@ public class TagSelectorPropertyDrawer : PropertyDrawer
         using (var scope = new EditorGUI.PropertyScope(position, label, property))
         {
             Tags.Update();
-            Debug.Log(Tags.IndexOf(property.stringValue));
             property.stringValue = Tags.Select(
-                EditorGUI.Popup(position, label.text, Tags.IndexOf(property.stringValue), Tags.tags));
+                EditorGUI.Popup(position, label.text, Tags.IndexOf(property.stringValue), Tags.DisplayNames));
         }
     }
 }

--- a/Assets/Code/ReadOnlyFieldAttribute.cs
+++ b/Assets/Code/ReadOnlyFieldAttribute.cs
@@ -1,0 +1,12 @@
+﻿// note: deliberately kept OUTSIDE the editor folder, where implementations can be found,
+//       so just think of this file as our `api` to our custom built attributes
+using UnityEngine;
+
+
+// example usage:
+//     [ReadOnlyFieldAttribute] [SerializeField] private string myStatus;
+//
+// note: see `Editor/TagSelectorPropertyDrawer` for implementation
+public class ReadOnlyFieldAttribute : PropertyAttribute
+{
+}

--- a/Assets/Code/ReadOnlyFieldAttribute.cs.meta
+++ b/Assets/Code/ReadOnlyFieldAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1cc74270a8bf4f498198d62259323eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/TagSelectorAttribute.cs
+++ b/Assets/Code/TagSelectorAttribute.cs
@@ -6,8 +6,10 @@ using UnityEngine;
 // example usage:
 //     [TagSelector] [SerializeField] private string[] tagsOfButtonsToHideOnMenuOpen = new string[] { };
 //
-// note: see `Editor/TagSelectorPropertyDrawer` for implementation
+// Notes
+// * see `Editor/TagSelectorPropertyDrawer` for implementation
+// * unlike the built in default tag selector in which a custom editor has to be written and the field is then
+// tagged like `EditorGUI.TagField(position, label, property.stringValue)`, this attribute works 'out of the box'
 public class TagSelectorAttribute : PropertyAttribute
 {
-    public bool UseDefaultTagFieldDrawer = false;
 }

--- a/Assets/Code/Utils/CollectionUtils.cs
+++ b/Assets/Code/Utils/CollectionUtils.cs
@@ -1,13 +1,107 @@
 ﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
 
 
 public static class CollectionUtils
 {
-    public static string[] PrependToArray(string value, string[] source)
+    public static T[] PrependToArray<T>(T value, T[] source)
     {
-        string[] newArray = new string[source.Length + 1];
+        T[] newArray = new T[source.Length + 1];
         newArray[0] = value;
         Array.Copy(source, 0, newArray, 1, source.Length);
         return newArray;
+    }
+
+    // assumes comparator Equals is defined for given element type
+    public static bool AreArraysEqual<T>(T[] array1, T[] array2)
+    {
+        if (ReferenceEquals(array1, array2))
+        {
+            return true;
+        }
+        if (array1 == null || array2 == null || array1.Length != array2.Length)
+        {
+            return false;
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+        for (int i = 0; i < array1.Length; i++)
+        {
+            if (!comparer.Equals(array1[i], array2[i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+    // Assumes
+    // * comparator `Equals` is defined for given element type
+    // * start <= array.length - 1
+    //
+    // Notes
+    // * segments considered equal IFF slice lengths AND each element are equal
+    public static bool AreArraySegmentsEqual<T>(T[] array1, T[] array2, int start1, int start2)
+    {
+        if (ReferenceEquals(array1, array2) && start1 == start2 && array1.Length == array2.Length)
+        {
+            return true;
+        }
+        if (array1 == null || array2 == null)
+        {
+            return false;
+        }
+
+        int count1 = array1.Length - start1;
+        int count2 = array2.Length - start2;
+        if (count1 != count2)
+        {
+            return false;
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+        for (int i = 0; i < count1; i++)
+        {
+            if (!comparer.Equals(array1[i + start1], array2[i + start2]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+    // Assumes
+    // * comparator `Equals` is defined for given element type
+    // * start <= array.length - 1
+    //
+    // Notes
+    // * segments considered equal IFF slice lengths AND each element are equal
+    // * if start + count exceeds array.length, then the segment spans to that point
+    public static bool AreArraySegmentsEqual<T>(T[] array1, T[] array2, int start1, int start2, int count1, int count2)
+    {
+        if (ReferenceEquals(array1, array2) && start1 == start2 && count1 == count2)
+        {
+            return true;
+        }
+
+        if (array1 == null || array2 == null)
+        {
+            return false;
+        }
+        int segmentLength1 = Mathf.Min(count1, array1.Length - start1);
+        int segmentLength2 = Mathf.Min(count2, array2.Length - start2);
+        if (segmentLength1 != segmentLength2)
+        {
+            return false;
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+        for (int i = 0; i < segmentLength1; i++)
+        {
+            if (!comparer.Equals(array1[i + start1], array2[i + start2]))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
# Custom PropertyDrawers: Tag selection and readonly
Some maintenance work on the tag selection property done in conjuction with a simple, new, readonlyfield attribute, both with caching applied.

Really not much to say here, the above summary and the code speaks for itself.

# Changelog
* Add caching to tagSelector attribute
* Replace guicontent array with displaynames
* Add readonly field attributes for displaying debug info in inspector
* Add array element comparison functions to collectionUtils