### PR TITLE
Player Mechanics: Expand ability to customize physics handling via player's inspector

### DIFF
--- a/Assets/Code/Controllers/PenguinController.cs
+++ b/Assets/Code/Controllers/PenguinController.cs
@@ -60,6 +60,10 @@ public class PenguinController : MonoBehaviour
     [SerializeField] [Range(SPEED_LIMIT_MIN, SPEED_LIMIT_MAX)]
     private float maxSpeed = SPEED_LIMIT_DEFAULT;
 
+    [Tooltip("Enable automatic locking of movement axes when non-moving " +
+             "(ie useful for reducing jitter, is enabled automatically when movement/input" +
+             " sensitivity is inside the thresholds set above)")]
+    [SerializeField] private bool enableAutomaticAxisLockingWhenIdle = true;
 
     [Header("Jump Settings")]
     [Tooltip("Strength of jump force in newtons")]
@@ -217,6 +221,8 @@ public class PenguinController : MonoBehaviour
     public void Reset()
     {
         UnlockAllAxes();
+        enableAutomaticAxisLockingWhenIdle = true;
+
         groundChecker.Reset();
         netImpulseForce = Vector2.zero;
         penguinRigidBody.velocity = Vector2.zero;
@@ -341,7 +347,7 @@ public class PenguinController : MonoBehaviour
             UnlockAllAxes();
             ClampSpeed();
         }
-        else
+        else if (enableAutomaticAxisLockingWhenIdle)
         {
             LockAllAxes();
         }

--- a/Assets/Code/Controllers/PenguinController.cs
+++ b/Assets/Code/Controllers/PenguinController.cs
@@ -43,22 +43,22 @@ public class PenguinController : MonoBehaviour
     [Header("Movement Settings")]
     [Tooltip("How strong are rotations to align with surface normal when moving up slopes? " +
              "(ie 0.0 for max softness, 1.0f for no kinematic softness)")]
-    [SerializeField] [Range(SURFACE_ALIGNMENT_STRENGTH_MIN, SURFACE_ALIGNMENT_STRENGTH_MAX)]
-    private float surfaceAlignmentRotationalStrength = SURFACE_ALIGNMENT_STRENGTH_DEFAULT;
+    [Range(SURFACE_ALIGNMENT_STRENGTH_MIN, SURFACE_ALIGNMENT_STRENGTH_MAX)]
+    [SerializeField] private float surfaceAlignmentRotationalStrength = SURFACE_ALIGNMENT_STRENGTH_DEFAULT;
 
     [Tooltip("How sensitive is the penguin to small rotational differences? " +
              "(ie 0.10 for ignoring differences of .10 degrees - useful for reducing jitter)")]
-    [SerializeField] [Range(ROTATIONAL_SENSITIVITY_MIN, ROTATIONAL_SENSITIVITY_MAX)]
-    private float misalignmentTolerance = ROTATIONAL_SENSITIVITY_DEFAULT;
+    [Range(ROTATIONAL_SENSITIVITY_MIN, ROTATIONAL_SENSITIVITY_MAX)]
+    [SerializeField] private float misalignmentTolerance = ROTATIONAL_SENSITIVITY_DEFAULT;
 
     [Tooltip("How sensitive is the penguin to small velocities? " +
              "(ie 0.10 for ignoring differences of .10 units - useful for reducing jitter)")]
-    [SerializeField] [Range(LINEAR_SENSITIVITY_MIN, LINEAR_SENSITIVITY_MAX)]
-    private float nonMovingTolerance = LINEAR_SENSITIVITY_DEFAULT;
+    [Range(LINEAR_SENSITIVITY_MIN, LINEAR_SENSITIVITY_MAX)]
+    [SerializeField] private float nonMovingTolerance = LINEAR_SENSITIVITY_DEFAULT;
 
     [Tooltip("How fast can the penguin move at its maximum? (ie clamping speed to 100)")]
-    [SerializeField] [Range(SPEED_LIMIT_MIN, SPEED_LIMIT_MAX)]
-    private float maxSpeed = SPEED_LIMIT_DEFAULT;
+    [Range(SPEED_LIMIT_MIN, SPEED_LIMIT_MAX)]
+    [SerializeField] private float maxSpeed = SPEED_LIMIT_DEFAULT;
 
     [Tooltip("Enable automatic locking of movement axes when non-moving " +
              "(ie useful for reducing jitter, is enabled automatically when movement/input" +
@@ -67,36 +67,36 @@ public class PenguinController : MonoBehaviour
 
     [Header("Jump Settings")]
     [Tooltip("Strength of jump force in newtons")]
-    [SerializeField] [Range(JUMP_STRENGTH_MIN, JUMP_STRENGTH_MAX)]
-    private float jumpStrength = JUMP_STRENGTH_DEFAULT;
+    [Range(JUMP_STRENGTH_MIN, JUMP_STRENGTH_MAX)]
+    [SerializeField] private float jumpStrength = JUMP_STRENGTH_DEFAULT;
 
     [Tooltip("Angle to jump (in degrees counterclockwise to the penguin's forward axis)")]
-    [SerializeField] [Range(JUMP_ANGLE_MIN, JUMP_ANGLE_MAX)]
-    private float jumpAngle = JUMP_ANGLE_DEFAULT;
+    [Range(JUMP_ANGLE_MIN, JUMP_ANGLE_MAX)]
+    [SerializeField] private float jumpAngle = JUMP_ANGLE_DEFAULT;
 
 
     [Header("Mass Settings")]
     [Tooltip("Constant (fixed) total mass for rigidbody")]
-    [SerializeField] [Range(MASS_MIN, MASS_MAX)]
-    private float mass = MASS_DEFAULT;
+    [Range(MASS_MIN, MASS_MAX)]
+    [SerializeField] private float mass = MASS_DEFAULT;
 
     [Tooltip("Center of mass x coordinate relative to skeleton root " +
              "(ie increase x and it will increase its tendency to lean forward)")]
-    [SerializeField] [Range(CENTER_OF_MASS_COORD_MIN, CENTER_OF_MASS_COORD_MAX)]
-    private float centerOfMassX = CENTER_OF_MASS_COORD_DEFAULT;
+    [Range(CENTER_OF_MASS_COORD_MIN, CENTER_OF_MASS_COORD_MAX)]
+    [SerializeField] private float centerOfMassX = CENTER_OF_MASS_COORD_DEFAULT;
 
     [Tooltip("Center of mass y coordinate relative to skeleton root " +
              "(ie increase y and it will increase its tendency to fall forward)")]
-    [SerializeField] [Range(CENTER_OF_MASS_COORD_MIN, CENTER_OF_MASS_COORD_MAX)]
-    private float centerOfMassY = CENTER_OF_MASS_COORD_DEFAULT;
+    [Range(CENTER_OF_MASS_COORD_MIN, CENTER_OF_MASS_COORD_MAX)]
+    [SerializeField] private float centerOfMassY = CENTER_OF_MASS_COORD_DEFAULT;
 
 
     [Header("Animation Settings")]
     [Tooltip("Amount of progress made per frame when transitioning between idle/moving states " +
              "(ie 0.05 for a blended delayed transition taking at least 20 frames," +
              " 1.00 for an instant transition with no blending)")]
-    [SerializeField] [Range(BLEND_SPEED_MIN, BLEND_SPEED_MAX)]
-    private float locomotionBlendSpeed = BLEND_SPEED_DEFAULT;
+    [Range(BLEND_SPEED_MIN, BLEND_SPEED_MAX)]
+    [SerializeField] private float locomotionBlendSpeed = BLEND_SPEED_DEFAULT;
 
 
     [Header("Collider References")]

--- a/Assets/Code/Utils/MathUtils.cs
+++ b/Assets/Code/Utils/MathUtils.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 // Convenience methods for math related functionality such as conversions, x-y plane vector computations, etc
 //
 // Notes
-// * rotational functionality is for the x-y plane unless otherwise stated, so that we can use lightweight trig rather
-// than using the less intuitive (especially for 2d), and heavier/more-generalized 3d quaternion methods in unity
+// * rotational functionality is for the x-y plane _unless_ otherwise stated, so that we can use lightweight trig rather
+//   than using the less intuitive (especially for 2d), and heavier/more-generalized 3d quaternion methods in unity
 public static class MathUtils
 {
     // computed the unsigned degrees (between [0, 90]) between given vec and x axis
@@ -45,14 +45,6 @@ public static class MathUtils
         return new Vector2(-vector.y, vector.x);
     }
 
-    public static Vector2 RotateClockwise_Q(Vector2 vector, float degrees)
-    {
-        return Quaternion.AngleAxis(-degrees, vector) * vector;
-    }
-    public static Vector2 RotateCounterClockwise_Q(Vector2 vector, float degrees)
-    {
-        return Quaternion.AngleAxis(degrees, vector) * vector;
-    }
     // return point rotated degrees clockwise about given local origin
     //
     // (determines point relative to origin, rotates, and translates back to get our newly rotated position)
@@ -63,7 +55,6 @@ public static class MathUtils
         float radians = degrees * Mathf.Deg2Rad;
         float cosTheta = Mathf.Cos(radians);
         float sinTheta = Mathf.Sin(radians);
-
         return new Vector2( (pointLocalToPivot.x * cosTheta) + (pointLocalToPivot.y * sinTheta) + pivot.x,
                            -(pointLocalToPivot.x * sinTheta) + (pointLocalToPivot.y * cosTheta) + pivot.y);
     }
@@ -77,9 +68,16 @@ public static class MathUtils
         float radians = degrees * Mathf.Deg2Rad;
         float cosTheta = Mathf.Cos(radians);
         float sinTheta = Mathf.Sin(radians);
-
         return new Vector2((pointLocalToPivot.x * cosTheta) - (pointLocalToPivot.y * sinTheta) + pivot.x,
                            (pointLocalToPivot.x * sinTheta) + (pointLocalToPivot.y * cosTheta) + pivot.y);
+    }
+    public static Vector2 RotateClockwise3D(Vector3 vector, float degrees)
+    {
+        return Quaternion.AngleAxis(-degrees, vector) * vector;
+    }
+    public static Vector2 RotateCounterClockwise3D(Vector3 vector, float degrees)
+    {
+        return Quaternion.AngleAxis(degrees, vector) * vector;
     }
 
     // perform a quick check for normalization without having to do the expensive magnitude calculation


### PR DESCRIPTION
# Expand ability to customize physics handling via player's inspector
Enhanced tooling for customizing the player's mechanics.

## Changelog
* Rotate transform instead of scaling such that transform.right is flipped correctly
* Reflect changes in center of mass given in inspector, IF rigidbody is active in scene
* Allow changing of mass through controller's inspector
* Add ability to change automatic locking of axes in inspector
* Move serialize field attributes to be placed after range attributes for controller fields