### PR TITLE
Penguin Character Redesign Part 3: Extracting out shared components

### DIFF
--- a/Assets/PenguinQuest/Code/Controllers/GroundHandler.cs
+++ b/Assets/PenguinQuest/Code/Controllers/GroundHandler.cs
@@ -7,7 +7,9 @@ namespace PenguinQuest.Controllers
 {
     [RequireComponent(typeof(Animator))]
     [RequireComponent(typeof(Rigidbody2D))]
+
     [RequireComponent(typeof(GroundChecker))]
+    [RequireComponent(typeof(PenguinSkeleton))]
     public class GroundHandler : MonoBehaviour
     {
         private const float ANGLE_THRESHOLD_DEFAULT            =  0.01f;
@@ -25,19 +27,18 @@ namespace PenguinQuest.Controllers
         [Range(SURFACE_ALIGNMENT_STRENGTH_MIN, SURFACE_ALIGNMENT_STRENGTH_MAX)]
         [SerializeField] private float surfaceAlignmentRotationalStrength = SURFACE_ALIGNMENT_STRENGTH_DEFAULT;
 
-        private Animator      penguinAnimator;
-        private Rigidbody2D   penguinRigidBody;
-        private GroundChecker groundChecker;
-
-        [SerializeField] private CapsuleCollider2D torsoCollider = default;
-
+        private Animator        penguinAnimator;
+        private Rigidbody2D     penguinRigidBody;
+        private GroundChecker   groundChecker;
+        private PenguinSkeleton penguinSkeleton;
 
         public void Reset()
         {
             groundChecker.Reset();
 
             // align penguin with surface normal in a single update
-            groundChecker.CheckForGround(fromPoint: ComputeReferencePoint(), extraLineHeight: torsoCollider.bounds.extents.y);
+            groundChecker.CheckForGround(fromPoint: ComputeReferencePoint(),
+                extraLineHeight: penguinSkeleton.ColliderTorso.bounds.extents.y);
             Vector2 targetUpAxis = groundChecker.WasDetected ? groundChecker.SurfaceNormalOfLastContact : Vector2.up;
             AlignPenguinWithUpAxis(targetUpAxis, forceInstantUpdate: true);
 
@@ -48,7 +49,8 @@ namespace PenguinQuest.Controllers
             penguinAnimator  = gameObject.GetComponent<Animator>();
             penguinRigidBody = gameObject.GetComponent<Rigidbody2D>();
             groundChecker    = gameObject.GetComponent<GroundChecker>();
-            
+            penguinSkeleton  = gameObject.GetComponent<PenguinSkeleton>();
+
             Reset();
         }
 
@@ -60,7 +62,8 @@ namespace PenguinQuest.Controllers
 
         void FixedUpdate()
         {
-            groundChecker.CheckForGround(fromPoint: ComputeReferencePoint(), extraLineHeight: torsoCollider.bounds.extents.y + 2.0f);
+            groundChecker.CheckForGround(fromPoint: ComputeReferencePoint(),
+                extraLineHeight: penguinSkeleton.ColliderTorso.bounds.extents.y);
             if (groundChecker.Result == default)
             {
                 return;

--- a/Assets/PenguinQuest/Code/Controllers/LieDownHandler.cs
+++ b/Assets/PenguinQuest/Code/Controllers/LieDownHandler.cs
@@ -5,21 +5,16 @@ using PenguinQuest.Data;
 namespace PenguinQuest.Controllers
 {
     [RequireComponent(typeof(Animator))]
+    [RequireComponent(typeof(PenguinSkeleton))]
     public class LieDownHandler : MonoBehaviour
     {
-        [Header("Collider References")]
-        [SerializeField] private CapsuleCollider2D headCollider              = default;
-        [SerializeField] private CapsuleCollider2D torsoCollider             = default;
-        [SerializeField] private CapsuleCollider2D frontFlipperUpperCollider = default;
-        [SerializeField] private CapsuleCollider2D frontFlipperLowerCollider = default;
-        [SerializeField] private CapsuleCollider2D frontFootCollider         = default;
-        [SerializeField] private CapsuleCollider2D backFootCollider          = default;
-
-        private Animator penguinAnimator;
+        private Animator        penguinAnimator;
+        private PenguinSkeleton penguinSkeleton;
 
         void Awake()
         {
             penguinAnimator = gameObject.GetComponent<Animator>();
+            penguinSkeleton = gameObject.GetComponent<PenguinSkeleton>();
         }
 
         void OnEnable()
@@ -42,13 +37,14 @@ namespace PenguinQuest.Controllers
         }
         void OnLieDownAnimationEventMid()
         {
-            frontFootCollider.enabled = false;
-            backFootCollider .enabled = false;
+            penguinSkeleton.ColliderConstraints =
+                PenguinColliderConstraints.DisableFeet;
         }
         void OnLieDownAnimationEventEnd()
         {
-            frontFlipperUpperCollider.enabled = false;
-            frontFlipperLowerCollider.enabled = false;
+            penguinSkeleton.ColliderConstraints =
+                PenguinColliderConstraints.DisableFeet |
+                PenguinColliderConstraints.DisableFlippers;
         }
     }
 }

--- a/Assets/PenguinQuest/Code/Controllers/PenguinBodyConfig.cs
+++ b/Assets/PenguinQuest/Code/Controllers/PenguinBodyConfig.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+
+namespace PenguinQuest.Code.Controllers
+{
+    public class PenguinBodyConfig : MonoBehaviour
+    {
+
+        void Start()
+        {
+
+        }
+
+        void Update()
+        {
+
+        }
+    }
+}

--- a/Assets/PenguinQuest/Code/Controllers/PenguinBodyConfig.cs.meta
+++ b/Assets/PenguinQuest/Code/Controllers/PenguinBodyConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71ffc5060e2f2f1489b668ed9ef4d588
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PenguinQuest/Code/Controllers/PenguinController.cs
+++ b/Assets/PenguinQuest/Code/Controllers/PenguinController.cs
@@ -5,10 +5,12 @@ using PenguinQuest.Data;
 
 namespace PenguinQuest.Controllers
 {
+
     [RequireComponent(typeof(JumpUpHandler))]
     [RequireComponent(typeof(StandUpHandler))]
     [RequireComponent(typeof(LieDownHandler))]
 
+    [RequireComponent(typeof(PenguinSkeleton))]
     [RequireComponent(typeof(Animator))]
     [RequireComponent(typeof(Rigidbody2D))]
     [RequireComponent(typeof(GroundChecker))]
@@ -70,19 +72,14 @@ namespace PenguinQuest.Controllers
         [Range(MASS_CENTER_COORD_MIN, MASS_CENTER_COORD_MAX)]
         [SerializeField] private float centerOfMassY = MASS_CENTER_COORD_DEFAULT;
 
-        [Header("Collider References")]
-        [SerializeField] private CapsuleCollider2D headCollider              = default;
-        [SerializeField] private CapsuleCollider2D torsoCollider             = default;
-        [SerializeField] private CapsuleCollider2D frontFlipperUpperCollider = default;
-        [SerializeField] private CapsuleCollider2D frontFlipperLowerCollider = default;
-        [SerializeField] private CapsuleCollider2D frontFootCollider         = default;
-        [SerializeField] private CapsuleCollider2D backFootCollider          = default;
         private enum Posture { UPRIGHT, ONBELLY, BENTOVER }
 
         private Vector2       initialSpawnPosition;
         private GroundChecker groundChecker;
-        private Rigidbody2D   penguinRigidBody;
-        private Animator      penguinAnimator;
+
+        private PenguinSkeleton penguinSkeleton;
+        private Rigidbody2D     penguinRigidBody;
+        private Animator        penguinAnimator;
 
         private Posture posture;
 
@@ -135,13 +132,17 @@ namespace PenguinQuest.Controllers
 
             // align penguin with surface normal in a single update
             posture = Posture.UPRIGHT;
-            groundChecker.CheckForGround(fromPoint: ComputeReferencePoint(), extraLineHeight: torsoCollider.bounds.extents.y);
+            groundChecker.CheckForGround(
+                fromPoint: ComputeReferencePoint(),
+                extraLineHeight: penguinSkeleton.ColliderTorso.bounds.extents.y
+            );
             Vector2 targetUpAxis = groundChecker.WasDetected ? groundChecker.SurfaceNormalOfLastContact : Vector2.up;
             AlignPenguinWithUpAxis(targetUpAxis, forceInstantUpdate: true);
             groundChecker.Reset();
         }
         void Awake()
         {
+            penguinSkeleton  = gameObject.GetComponent<PenguinSkeleton>();
             penguinAnimator  = gameObject.GetComponent<Animator>();
             penguinRigidBody = gameObject.GetComponent<Rigidbody2D>();
             groundChecker    = gameObject.GetComponent<GroundChecker>();
@@ -178,7 +179,10 @@ namespace PenguinQuest.Controllers
 
         void Update()
         {
-            groundChecker.CheckForGround(fromPoint: ComputeReferencePoint(), extraLineHeight: torsoCollider.bounds.extents.y);
+            groundChecker.CheckForGround(
+                fromPoint:       ComputeReferencePoint(),
+                extraLineHeight: penguinSkeleton.ColliderTorso.bounds.extents.y
+            );
             UpdateAnimatorParameters();
         }
 

--- a/Assets/PenguinQuest/Code/Controllers/PenguinSkeleton.cs
+++ b/Assets/PenguinQuest/Code/Controllers/PenguinSkeleton.cs
@@ -1,0 +1,97 @@
+using UnityEngine;
+
+
+namespace PenguinQuest.Controllers
+{
+    [System.Flags]
+    public enum PenguinColliderConstraints
+    {
+        None            = 0,
+        DisableHead     = 1 << 2,
+        DisableTorso    = 1 << 3,
+        DisableFlippers = 1 << 4,
+        DisableFeet     = 1 << 5,
+        DisableAll      = ~0,
+    }
+
+    [System.Serializable]
+    [AddComponentMenu("Penguin Skeleton")]
+    public class PenguinSkeleton : MonoBehaviour
+    {
+        [Header("Collider Constraints")]
+        [SerializeField] private PenguinColliderConstraints _constraints = PenguinColliderConstraints.None;
+
+        [Header("Collider References")]
+        [SerializeField] private CapsuleCollider2D headCollider              = default;
+        [SerializeField] private CapsuleCollider2D torsoCollider             = default;
+        [SerializeField] private CapsuleCollider2D frontFlipperUpperCollider = default;
+        [SerializeField] private CapsuleCollider2D frontFlipperLowerCollider = default;
+        [SerializeField] private CapsuleCollider2D frontFootCollider         = default;
+        [SerializeField] private CapsuleCollider2D backFootCollider          = default;
+        
+        public Collider2D ColliderHead              => headCollider;
+        public Collider2D ColliderTorso             => torsoCollider;
+        public Collider2D ColliderFrontFlipperUpper => frontFlipperUpperCollider;
+        public Collider2D ColliderFrontFlipperLower => frontFlipperLowerCollider;
+        public Collider2D ColliderFrontFoot         => frontFootCollider;
+        public Collider2D ColliderBackFoot          => backFootCollider;
+
+
+        public PenguinColliderConstraints ColliderConstraints
+        {
+            get
+            {
+                // the colliders may have been enabled/disabled individually elsewhere, so synchronize the mask
+                _constraints = GetConstraintsAccordingToDisabledColliders();
+                return _constraints;
+            }
+            set
+            {
+                // ignore all other flags if none is selected, and if none is not selected then use all overrides everything else
+                _constraints = value;
+                if (_constraints.HasFlag(PenguinColliderConstraints.None))
+                {
+                    _constraints = PenguinColliderConstraints.None;
+                }
+                else if (_constraints.HasFlag(PenguinColliderConstraints.DisableAll))
+                {
+                    _constraints = PenguinColliderConstraints.DisableAll;
+                }
+                UpdateColliderEnabilityAccordingToConstraints(_constraints);
+            }
+        }
+        
+        private void UpdateColliderEnabilityAccordingToConstraints(PenguinColliderConstraints constraints)
+        {
+            ColliderHead             .enabled = !constraints.HasFlag(PenguinColliderConstraints.DisableHead);
+            ColliderTorso            .enabled = !constraints.HasFlag(PenguinColliderConstraints.DisableTorso);
+            ColliderFrontFlipperUpper.enabled = !constraints.HasFlag(PenguinColliderConstraints.DisableFlippers);
+            ColliderFrontFlipperLower.enabled = !constraints.HasFlag(PenguinColliderConstraints.DisableFlippers);
+            ColliderFrontFoot        .enabled = !constraints.HasFlag(PenguinColliderConstraints.DisableFeet);
+            ColliderBackFoot         .enabled = !constraints.HasFlag(PenguinColliderConstraints.DisableFeet);
+        }
+
+        private PenguinColliderConstraints GetConstraintsAccordingToDisabledColliders()
+        {
+            // note that if the field corresponds to more than one collider, all must be disabled
+            PenguinColliderConstraints constraints = PenguinColliderConstraints.None;
+            if (!headCollider.enabled)
+            {
+                constraints |= PenguinColliderConstraints.DisableHead;
+            }
+            if (!torsoCollider.enabled)
+            {
+                constraints |= PenguinColliderConstraints.DisableTorso;
+            }
+            if (!frontFlipperUpperCollider.enabled && !frontFlipperLowerCollider.enabled)
+            {
+                constraints |= PenguinColliderConstraints.DisableFlippers;
+            }
+            if (!frontFootCollider.enabled && !backFootCollider.enabled)
+            {
+                constraints |= PenguinColliderConstraints.DisableFeet;
+            }
+            return constraints;
+        }
+    }
+}

--- a/Assets/PenguinQuest/Code/Controllers/PenguinSkeleton.cs.meta
+++ b/Assets/PenguinQuest/Code/Controllers/PenguinSkeleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85d65616f85963544a31440ebe3f55bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PenguinQuest/Code/Controllers/StandUpHandler.cs
+++ b/Assets/PenguinQuest/Code/Controllers/StandUpHandler.cs
@@ -5,21 +5,16 @@ using PenguinQuest.Data;
 namespace PenguinQuest.Controllers
 {
     [RequireComponent(typeof(Animator))]
+    [RequireComponent(typeof(PenguinSkeleton))]
     public class StandUpHandler : MonoBehaviour
     {
-        [Header("Collider References")]
-        [SerializeField] private CapsuleCollider2D headCollider              = default;
-        [SerializeField] private CapsuleCollider2D torsoCollider             = default;
-        [SerializeField] private CapsuleCollider2D frontFlipperUpperCollider = default;
-        [SerializeField] private CapsuleCollider2D frontFlipperLowerCollider = default;
-        [SerializeField] private CapsuleCollider2D frontFootCollider         = default;
-        [SerializeField] private CapsuleCollider2D backFootCollider          = default;
-
-        private Animator penguinAnimator;
+        private Animator        penguinAnimator;
+        private PenguinSkeleton penguinSkeleton;
 
         void Awake()
         {
             penguinAnimator = gameObject.GetComponent<Animator>();
+            penguinSkeleton = gameObject.GetComponent<PenguinSkeleton>();
         }
 
         void OnEnable()
@@ -38,10 +33,7 @@ namespace PenguinQuest.Controllers
         }
         void OnStandUpAnimationEventStart()
         {
-            frontFlipperUpperCollider.enabled = true;
-            frontFlipperLowerCollider.enabled = true;
-            frontFootCollider        .enabled = true;
-            backFootCollider         .enabled = true;
+            penguinSkeleton.ColliderConstraints = PenguinColliderConstraints.None;
         }
         void OnStandUpAnimationEventEnd()
         {

--- a/Assets/PenguinQuest/Scenes/FeatureSandbox/fsm_test.unity
+++ b/Assets/PenguinQuest/Scenes/FeatureSandbox/fsm_test.unity
@@ -4253,7 +4253,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 483879405}
-  m_LocalRotation: {x: 3e-45, y: -3e-45, z: -0.000000026077032, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: -0.000000026077025, w: 1}
   m_LocalPosition: {x: 2, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -4285,7 +4285,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 535552563}
   m_LocalRotation: {x: -0, y: -0, z: -0.6972611, w: 0.7168172}
-  m_LocalPosition: {x: 9.019308, y: -4.6811543, z: 0}
+  m_LocalPosition: {x: 9.01931, y: -4.6811543, z: 0}
   m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4488,7 +4488,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 821338711}
   m_LocalRotation: {x: -0, y: -0, z: 0.6781434, w: 0.7349297}
-  m_LocalPosition: {x: -1.8582615, y: 7.581731, z: 0}
+  m_LocalPosition: {x: -1.8582615, y: 7.5817313, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4589,7 +4589,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 888909198}
   m_LocalRotation: {x: -0, y: -0, z: 0.087852016, w: 0.99613357}
-  m_LocalPosition: {x: 1.2183477, y: 0.5946146, z: 0.04}
+  m_LocalPosition: {x: 1.2183471, y: 0.59461653, z: 0.04}
   m_LocalScale: {x: 0.9999999, y: 0.9999999, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4682,7 +4682,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1171346593}
   m_LocalRotation: {x: -0, y: -0, z: 0.9752069, w: -0.22129518}
-  m_LocalPosition: {x: -5.540299, y: 2.35281, z: 0}
+  m_LocalPosition: {x: -5.5402994, y: 2.35281, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4775,7 +4775,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1270679483}
   m_LocalRotation: {x: -0, y: -0, z: 0.07733771, w: 0.99700505}
-  m_LocalPosition: {x: 3.6907115, y: 0.7725042, z: 0}
+  m_LocalPosition: {x: 3.6907096, y: 0.7725054, z: 0}
   m_LocalScale: {x: 0.9999999, y: 0.9999999, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4902,7 +4902,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1391181275}
   m_LocalRotation: {x: -0, y: -0, z: -0.98698515, w: 0.16081144}
-  m_LocalPosition: {x: -12.466672, y: -0.52379614, z: 0}
+  m_LocalPosition: {x: -12.466672, y: -0.52379656, z: 0}
   m_LocalScale: {x: 0.99999976, y: 0.99999976, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4992,6 +4992,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1429373696}
   - component: {fileID: 1429373700}
+  - component: {fileID: 1429373710}
   - component: {fileID: 1429373703}
   - component: {fileID: 1429373697}
   - component: {fileID: 1429373699}
@@ -5117,12 +5118,6 @@ MonoBehaviour:
   mass: 250
   centerOfMassX: 0
   centerOfMassY: 0
-  headCollider: {fileID: 1904906742}
-  torsoCollider: {fileID: 560952285}
-  frontFlipperUpperCollider: {fileID: 1297167880}
-  frontFlipperLowerCollider: {fileID: 1960767493}
-  frontFootCollider: {fileID: 207128432}
-  backFootCollider: {fileID: 1325789281}
 --- !u!114 &1429373704
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5135,12 +5130,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 81356bfedf5336c40973882ce9730bc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  headCollider: {fileID: 1904906742}
-  torsoCollider: {fileID: 560952285}
-  frontFlipperUpperCollider: {fileID: 1297167880}
-  frontFlipperLowerCollider: {fileID: 1960767493}
-  frontFootCollider: {fileID: 207128432}
-  backFootCollider: {fileID: 1325789281}
 --- !u!114 &1429373705
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5153,12 +5142,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03575db054bb040478b656105bc59aa5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  headCollider: {fileID: 1904906742}
-  torsoCollider: {fileID: 560952285}
-  frontFlipperUpperCollider: {fileID: 1297167880}
-  frontFlipperLowerCollider: {fileID: 1960767493}
-  frontFootCollider: {fileID: 207128432}
-  backFootCollider: {fileID: 1325789281}
 --- !u!114 &1429373706
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5200,7 +5183,25 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   degreesFromSurfaceNormalThreshold: 0.01
   surfaceAlignmentRotationalStrength: 0.1
+--- !u!114 &1429373710
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1429373695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85d65616f85963544a31440ebe3f55bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  headCollider: {fileID: 1904906742}
   torsoCollider: {fileID: 560952285}
+  frontFlipperUpperCollider: {fileID: 1297167880}
+  frontFlipperLowerCollider: {fileID: 1960767493}
+  frontFootCollider: {fileID: 207128432}
+  backFootCollider: {fileID: 1325789281}
+  _constraints: 0
 --- !u!1001 &1522957906
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5370,7 +5371,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1527207744}
   m_LocalRotation: {x: -0, y: -0, z: 0.15238322, w: 0.98832154}
-  m_LocalPosition: {x: 1.3217127, y: 0.39862347, z: 0.04}
+  m_LocalPosition: {x: 1.3217123, y: 0.3986253, z: 0.04}
   m_LocalScale: {x: 0.9999999, y: 0.9999999, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5465,7 +5466,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1690546333}
   m_LocalRotation: {x: -0, y: -0, z: 0.61160827, w: 0.7911608}
-  m_LocalPosition: {x: -1.1993266, y: 19.049635, z: 0}
+  m_LocalPosition: {x: -1.1993268, y: 19.049635, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5629,7 +5630,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1788758789}
-  m_LocalRotation: {x: 1e-45, y: 1e-45, z: -0.000000029802312, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: -0.000000029802312, w: 1}
   m_LocalPosition: {x: 5.22, y: 0.88, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -5861,7 +5862,7 @@ MonoBehaviour:
     - {x: 0, y: 0, z: 0.13265814, w: 0.9911619}
     - {x: 0, y: 0, z: -0.4310487, w: 0.90232867}
     - {x: 0, y: 0, z: -0.45819503, w: 0.8888517}
-    - {x: 1e-45, y: 1e-45, z: -0.000000029802312, w: 1}
+    - {x: 0, y: 0, z: -0.000000029802312, w: 1}
   m_Iterations: 15
   m_Tolerance: 0.01
   m_Velocity: 0.5
@@ -6046,7 +6047,7 @@ MonoBehaviour:
     m_StoredLocalRotations:
     - {x: 0, y: 0, z: 0.005699533, w: 0.9999838}
     - {x: 0, y: 0, z: -0.037286036, w: 0.99930465}
-    - {x: 3e-45, y: -3e-45, z: -0.000000026077032, w: 1}
+    - {x: 0, y: 0, z: -0.000000026077025, w: 1}
   m_Iterations: 15
   m_Tolerance: 0.01
   m_Velocity: 0.5


### PR DESCRIPTION
# Penguin Character Redesign Part 3: Extracting out shared components
Previously, we had components assigned in the inspector for the penguin skeleton in all the scripts that needed it, but obviously this is redundant and more error prone due to the amount of places that would need to be updated at if the collider structure ever changes.

Thus, I extracted out all those into a shared component with properties for each collider, and a handy bit mask constraints field for much easier collider enable/disable toggling, see below:
![image](https://user-images.githubusercontent.com/8084757/148700548-447c2582-6860-4ce2-8e45-ffbb41e36e2c.png)

Next PR we will get around to ground handling.
