### PR TITLE
Make handling of null and disabled colliders more robust

### DIFF
--- a/Assets/PenguinQuest/Code/Controllers/AlwaysOnComponents/BoxPerimeterRayCaster.cs
+++ b/Assets/PenguinQuest/Code/Controllers/AlwaysOnComponents/BoxPerimeterRayCaster.cs
@@ -52,7 +52,7 @@ namespace PenguinQuest.Controllers.AlwaysOnComponents
         public ReadOnlySpan<CastResult> TopResults    => _results.AsSpan(_topStartIndex,    NumRaysPerHorizontalSide);
         public ReadOnlySpan<CastResult> LeftResults   => _results.AsSpan(_leftStartIndex,   NumRaysPerVerticalSide);
         public ReadOnlySpan<CastResult> RightResults  => _results.AsSpan(_rightStartIndex,  NumRaysPerVerticalSide);
-      
+
         public BoxPerimeterRayCaster(BoxCollider2D box, RayCasterSettings settings)
         {
             this._box          = box;
@@ -68,6 +68,11 @@ namespace PenguinQuest.Controllers.AlwaysOnComponents
 
         public void CastAll()
         {
+            if (!_box)
+            {
+                return;
+            }
+
             UpdateOrientedBounds(_box.bounds, _box.transform, Settings.Offset);
             ComputeRaySpacingAndCounts(Settings.DistanceBetweenRays, _originBounds.Size);
 
@@ -90,7 +95,7 @@ namespace PenguinQuest.Controllers.AlwaysOnComponents
 
         private CastResult Cast(Vector2 origin, Vector2 direction)
         {
-            return _lineCaster.CastFromPoint(origin, direction, Settings.MaxDistance);
+            return _lineCaster.CastFromPoint(origin, direction);
         }
 
         private void UpdateOrientedBounds(Bounds bounds, Transform transform, float boundsOffset)

--- a/Assets/PenguinQuest/Code/Controllers/AlwaysOnComponents/CollisionChecker.cs
+++ b/Assets/PenguinQuest/Code/Controllers/AlwaysOnComponents/CollisionChecker.cs
@@ -33,15 +33,20 @@ namespace PenguinQuest.Controllers.AlwaysOnComponents
 
         void FixedUpdate()
         {
-            CheckForGround();
+            if (colliderToCastFrom)
+            {
+                CheckForGround();
+            }
         }
-
+        
         public void CheckForGround()
         {
             _perimeterCaster.CastAll();
+            CastHit? groundHit = _perimeterCaster.BottomResults.IsEmpty ?
+                null :
+                _perimeterCaster.BottomResults[1].hit;
 
-            CastHit? hit = _perimeterCaster.BottomResults[1].hit;
-            if (hit.HasValue && hit.Value.distance <= toleratedDistanceFromGround)
+            if (groundHit.HasValue && groundHit.Value.distance <= toleratedDistanceFromGround)
             {
                 IsGrounded    = true;
                 SurfaceNormal = _perimeterCaster.BottomResults[1].hit.Value.normal;

--- a/Assets/PenguinQuest/Code/Controllers/Handlers/LieDownHandler.cs
+++ b/Assets/PenguinQuest/Code/Controllers/Handlers/LieDownHandler.cs
@@ -46,24 +46,32 @@ namespace PenguinQuest.Controllers.Handlers
         void OnLieDownAnimationEventStart()
         {
             penguinEntity.Animation.SetParamIsUpright(false);
-            penguinEntity.ColliderConstraints |=
+
+            // disable our box and feet, to prevent catching on edges when changing posture from OnFeet to OnBelly
+            penguinEntity.ColliderConstraints =
                 PenguinColliderConstraints.DisableBoundingBox |
                 PenguinColliderConstraints.DisableFeet;
         }
 
         void OnLieDownAnimationEventMid()
         {
-            penguinEntity.ColliderConstraints |=
-                PenguinColliderConstraints.DisableFeet;
+            // disable our box and feet, to prevent catching on edges when changing posture from OnFeet to OnBelly
+            penguinEntity.ColliderConstraints =
+                PenguinColliderConstraints.DisableBoundingBox |
+                PenguinColliderConstraints.DisableFeet        |
+                PenguinColliderConstraints.DisableFlippers;
         }
 
         void OnLieDownAnimationEventEnd()
         {
             // todo: this stuff needs to go in the state machine
             characterController.Settings = lieDownStateCharacterSettings;
-            penguinEntity.ColliderConstraints |=
-                PenguinColliderConstraints.DisableFeet |
-                PenguinColliderConstraints.DisableFlippers;
+
+            // keep our feet and flippers disabled to avoid interference with ground while OnBelly,
+            // but enable everything else including bounding box
+            penguinEntity.ColliderConstraints =
+                 PenguinColliderConstraints.DisableFeet |
+                 PenguinColliderConstraints.DisableFlippers;
 
 
             // todo: find a good way of having data for sliding and for upright that can be passed in here,

--- a/Assets/PenguinQuest/Code/Controllers/Handlers/StandUpHandler.cs
+++ b/Assets/PenguinQuest/Code/Controllers/Handlers/StandUpHandler.cs
@@ -43,11 +43,9 @@ namespace PenguinQuest.Controllers.Handlers
 
         void OnStandUpAnimationEventStart()
         {
-            penguinEntity.ColliderConstraints = PenguinColliderConstraints.None;
-
-            // enable the feet again, allowing the penguin to 'fall' down to alignment
-            penguinEntity.ColliderConstraints &=
-                ~PenguinColliderConstraints.DisableFeet;
+            // keep all colliders on _except_ for the bounding box, to prevent catching on edges during posture change
+            penguinEntity.Animation.SetParamIsGrounded(true);
+            penguinEntity.ColliderConstraints = PenguinColliderConstraints.DisableBoundingBox;
         }
 
         void OnStandUpAnimationEventEnd()
@@ -56,9 +54,8 @@ namespace PenguinQuest.Controllers.Handlers
             penguinEntity.Animation.SetParamIsUpright(true);
             characterController.Settings = uprightStateCharacterSettings;
 
-            // enable the bounding box again, allowing the penguin to 'fall' down to alignment
-            penguinEntity.ColliderConstraints &=
-                ~PenguinColliderConstraints.DisableBoundingBox;
+            // enable all colliders as we are now fully upright
+            penguinEntity.ColliderConstraints = PenguinColliderConstraints.None;
 
             // todo: find a good way of having data for sliding and for upright that can be passed in here,
             //       and those values can be adjusted, perhaps in their own scriptable objects?

--- a/Assets/PenguinQuest/Code/Data/RayCasts.cs
+++ b/Assets/PenguinQuest/Code/Data/RayCasts.cs
@@ -46,18 +46,18 @@ namespace PenguinQuest.Data
         }
 
         /* Shoot out a line from point to max distance from that point until a TargetLayer is hit. */
-        public CastResult CastFromPoint(Vector2 point, Vector2 direction, float distance)
+        public CastResult CastFromPoint(Vector2 point, Vector2 direction)
         {
-            return CastLine(point, point + (distance * direction));
+            return CastLine(point, point + (Settings.MaxDistance * direction));
         }
 
         /* Shoot out a line from edge of collider to distance from that point until a TargetLayer is hit. */
-        public CastResult CastFromCollider(Collider2D collider, Vector2 direction, float distance)
+        public CastResult CastFromCollider(Collider2D collider, Vector2 direction)
         {
             Vector2 point = FindPositionOnColliderEdgeInGivenDirection(collider, direction);
-            return CastLine(point, point + (distance * direction));
+            return CastLine(point, point + (Settings.MaxDistance * direction));
         }
-        
+
         /* Shoot out a line between given points, seeing if a TargetLayer is hit. */
         public CastResult CastBetween(Vector2 from, Vector2 to)
         {
@@ -74,10 +74,15 @@ namespace PenguinQuest.Data
             Vector2 end    = to   + offset;
             
             CastHit? hit = null;
-            RaycastHit2D rayHit = Physics2D.Linecast(start, end, layerMask);
-            if (rayHit)
+            RaycastHit2D castHit2D = Physics2D.Linecast(start, end, layerMask);
+            if (castHit2D)
             {
-                hit = new CastHit(rayHit.point, rayHit.normal, rayHit.distance - Mathf.Abs(offsetAmount), rayHit.collider);
+                hit = new CastHit(
+                    point:    castHit2D.point,
+                    normal:   castHit2D.normal,
+                    distance: castHit2D.distance - Mathf.Abs(offsetAmount),
+                    collider: castHit2D.collider
+                );
             }
 
             return new CastResult(start, end, hit);


### PR DESCRIPTION
Makes disabling of colliders more sensible with some useful commentary on the why, and avoids possible nullreferences if the BoxPerimeterRayCaster tries to cast from an inactive/null collider.