### PR TITLE
Penguin Character Redesign Part 9: Use normals for alignment even if not grounded

### DIFF
--- a/Assets/PenguinQuest/Code/Controllers/AlwaysOnComponents/CollisionChecker.cs
+++ b/Assets/PenguinQuest/Code/Controllers/AlwaysOnComponents/CollisionChecker.cs
@@ -13,7 +13,7 @@ namespace PenguinQuest.Controllers.AlwaysOnComponents
     For example, is there something X distance in front of me?
     What about the front half of the box's bottom side?
 
-    TODO: Account for different layers and different sides being activated/deativated etc?
+    TODO: Account for different layers and different sides being activated/deactivated etc?
     */
     public class CollisionChecker : MonoBehaviour
     {

--- a/Assets/PenguinQuest/Code/Controllers/AlwaysOnComponents/CollisionChecker.cs
+++ b/Assets/PenguinQuest/Code/Controllers/AlwaysOnComponents/CollisionChecker.cs
@@ -1,6 +1,8 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using PenguinQuest.Utils;
 using PenguinQuest.Data;
+
 
 
 namespace PenguinQuest.Controllers.AlwaysOnComponents
@@ -42,20 +44,34 @@ namespace PenguinQuest.Controllers.AlwaysOnComponents
         public void CheckForGround()
         {
             _perimeterCaster.CastAll();
-            CastHit? groundHit = _perimeterCaster.BottomResults.IsEmpty ?
-                null :
-                _perimeterCaster.BottomResults[1].hit;
-
-            if (groundHit.HasValue && groundHit.Value.distance <= toleratedDistanceFromGround)
+            if (HasHitAtLeastOneWithinDistance(_perimeterCaster.BottomResults, toleratedDistanceFromGround, out CastHit hit))
             {
                 IsGrounded    = true;
-                SurfaceNormal = _perimeterCaster.BottomResults[1].hit.Value.normal;
+                SurfaceNormal = hit.normal;
             }
             else
             {
                 IsGrounded    = false;
                 SurfaceNormal = Vector2.up;
             }
+        }
+
+        private bool HasHitAtLeastOneWithinDistance(ReadOnlySpan<CastResult> results, float distance, out CastHit hit)
+        {            
+            // todo: account for different layers and stuff
+            // todo: try from left to right
+            // todo: figure out a proper way of 'capturing' normal - perhaps a downward sphere cast centroid result?
+            //       ...or maybe just look at how seblag handled it...averages or something?
+            foreach (CastResult result in results)
+            {
+                if (result.hit.HasValue && result.hit.Value.distance <= distance)
+                {
+                    hit = result.hit.Value;
+                    return true;
+                }
+            }
+            hit = default;
+            return false;
         }
         
         #if UNITY_EDITOR

--- a/Assets/PenguinQuest/ScriptableObjects/PenguinPerimeterCasterSettings.asset
+++ b/Assets/PenguinQuest/ScriptableObjects/PenguinPerimeterCasterSettings.asset
@@ -12,9 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8d78141fe98f00b4a96924ba4cc63655, type: 3}
   m_Name: PenguinPerimeterCasterSettings
   m_EditorClassIdentifier: 
-  distanceBetweenRays: 0.25
+  distanceBetweenRays: 0.5
   rayCastOffset: 0.25
-  maxRayDistance: 5
+  maxRayDistance: 7.5
   targetLayers:
     serializedVersion: 2
     m_Bits: 256


### PR DESCRIPTION
# Penguin Character Redesign Part 9: Use normals for alignment even if not grounded
Seperates out normal and grounded checks, as they don't neccesarily correspond to what we want the alignment to be.
For example, if the penguin has both ends making ground contact, but the middle isn't, it will now try to align with the slope of what is immediately downward from the penguin. This may change in the future, but makes things a bit more adaptable for now.