### PR TITLE
Kinematic Part 4: Flesh out boxCaster functionality and integrate it across the codebase

### DIFF
--- a/Assets/Code/Entities/Character2D.cs
+++ b/Assets/Code/Entities/Character2D.cs
@@ -36,11 +36,17 @@ namespace PQ.Entities
         {
             _body = gameObject.GetComponent<KinematicBody2D>();
             _casterBox = gameObject.GetComponent<RayCasterBox>();
+
+            // todo: add proper config settings for things like this, and set these using those values
+            _casterBox.BackSensorSpacing   = 0.50f;
+            _casterBox.FrontSensorSpacing  = 0.50f;
+            _casterBox.BottomSensorSpacing = 0.50f;
+            _casterBox.TopSensorSpacing    = 0.50f;
         }
 
         void Start()
         {
-            UpdateGroundContactInfo();
+            UpdateGroundContactInfo(force: true);
         }
 
         void FixedUpdate()
@@ -56,7 +62,9 @@ namespace PQ.Entities
 
         private void UpdateGroundContactInfo(bool force = false)
         {
-            bool isInContactWithGround = _casterBox.BottomSensorResults.hitPercentage > 0f;
+            // todo: use a scriptable object or something for these checks
+            var result = _casterBox.CheckBelow(target: LayerMask.GetMask("Platform"), distance: int.MaxValue);
+            bool isInContactWithGround = result.hitPercentage >= 0.50f && result.hitDistance <= 0.25f;
 
             if (_isGrounded != isInContactWithGround || force)
             {

--- a/Assets/Code/_Common/RayCasterSegment.cs
+++ b/Assets/Code/_Common/RayCasterSegment.cs
@@ -63,7 +63,8 @@ namespace PQ.Common
             _results   = Array.Empty<RayCaster.Hit?>();
             _rayCaster = new RayCaster();
             UpdatePositioning(start, end, distanceBetweenRays);
-            UpdateCastParams(castDirection, layerMask: ~0, maxDistance: Mathf.Infinity);
+            UpdateCastDirection(castDirection);
+            UpdateCastOptions(layerMask: ~0, maxDistance: Mathf.Infinity);
         }
 
         /* Between which points and with how much gap should ray origins be placed? */
@@ -75,7 +76,9 @@ namespace PQ.Common
 
             int rayCount;
             float raySpacing;
-            if (Mathf.Approximately(segmentDistance, 0f) || segmentDirection != Vector2.zero)
+            if (segmentDirection != Vector2.zero ||
+                Mathf.Approximately(segmentDistance, 0f) ||
+                Mathf.Approximately(distanceBetweenRays, 0f))
             {
                 rayCount   = 1;
                 raySpacing = 0.5f;
@@ -95,10 +98,15 @@ namespace PQ.Common
             }
         }
 
-        /* In what direction, what layers, and for what distance should we cast rays? */
-        public void UpdateCastParams(Vector2 rayDirection, LayerMask layerMask, float maxDistance)
+        /* In what direction should we cast rays? */
+        public void UpdateCastDirection(Vector2 rayDirection)
         {
-            _rayDir                = rayDirection.normalized;
+            _rayDir = rayDirection.normalized;
+        }
+
+        /* What layers, and for what distance should we cast rays? */
+        public void UpdateCastOptions(LayerMask layerMask, float maxDistance)
+        {
             _rayCaster.LayerMask   = layerMask;
             _rayCaster.MaxDistance = maxDistance;
         }

--- a/Assets/Prefabs/Penguin.prefab
+++ b/Assets/Prefabs/Penguin.prefab
@@ -263,6 +263,7 @@ GameObject:
   - component: {fileID: 4753795910216235721}
   - component: {fileID: 7859832108952071242}
   - component: {fileID: 2138608317391900897}
+  - component: {fileID: 844064212498705148}
   - component: {fileID: 331518940653301218}
   - component: {fileID: 1728887597599890734}
   - component: {fileID: 4753795910216235732}
@@ -367,6 +368,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a28484ee5f1151f4dae5545688b2f5ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &844064212498705148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4753795910216235740}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce58fd52abec0ba498285837d34f864d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &331518940653301218

--- a/Assets/Scenes/Test_Minimal/Player_Block.prefab
+++ b/Assets/Scenes/Test_Minimal/Player_Block.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1001543055492729391}
   - component: {fileID: 4765852279069534298}
   - component: {fileID: 6424954451660586289}
+  - component: {fileID: -6384245666304517564}
   - component: {fileID: 1743938938977150192}
   - component: {fileID: 1106268956338744581}
   m_Layer: 9
@@ -146,6 +147,18 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a28484ee5f1151f4dae5545688b2f5ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &-6384245666304517564
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3204818302733060367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce58fd52abec0ba498285837d34f864d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1743938938977150192


### PR DESCRIPTION
# Kinematic Part 4: Flesh out boxCaster functionality and integrate it across the codebase
Streamlines the interface of boxCaster, fleshes out the casting logic, and utilizes it with dummy values. Now the penguin can walk sideways fine and skips to the correct state, without using dynamic physics at all! :)

Note that this is a continuation of [Kinematic Part 3: Initial reimplementation of casters](https://github.com/jeffreypersons/Penguin-Quest/pull/114), with this PR fleshing out the functionality that was laid-out/revamped previously. Next PR will entail properly computing useful information on cast results (eg standard deviation of hits, etc).