### PR TITLE
Kinematic Part 5: Fixing and simplifying ray casting

### DIFF
--- a/Assets/Code/Entities/Character2DSettings.cs
+++ b/Assets/Code/Entities/Character2DSettings.cs
@@ -21,9 +21,6 @@ namespace PQ.Entities
         public float   SurfaceAlignmentRotationalStrength => _surfaceAlignmentRotationalStrength;
         public float   DegreesFromSurfaceNormalThreshold  => _degreesFromSurfaceNormalThreshold;
 
-        public float   LinearVelocityThreshold            => _linearVelocityThreshold;
-        public float   AngularVelocityThreshold           => _angularVelocityThreshold;
-
 
         [Header("Animation Settings")]
         [Tooltip("Step size used to adjust blend percent when transitioning between idle/moving states" +
@@ -64,17 +61,5 @@ namespace PQ.Entities
 
         [Tooltip("At what degrees between up axis and surface normal is considered to be misaligned?")]
         [SerializeField] [Range(0.01f, 20.00f)] private float _degreesFromSurfaceNormalThreshold = 0.01f;
-
-
-        [Header("Movement Sensitives (Tolerances for Jitter Reduction)")]
-
-        [Tooltip("Should we automatically lock movement axes when velocities are within thresholds?")]
-        [SerializeField] private bool _enableAutomaticAxisLockingForSmallVelocities = true;
-
-        [Tooltip("What linear velocities (in x or y units) do we consider to be small enough to ignore?")]
-        [SerializeField] [Range(0.01f, 20.00f)] private float _linearVelocityThreshold = 5.00f;
-
-        [Tooltip("What angular velocities (in degrees) do we consider to be small enough to ignore?")]
-        [SerializeField] [Range(0.01f, 20.00f)] private float _angularVelocityThreshold = 5.00f;
     }
 }

--- a/Assets/Code/_Common/RayCaster.cs
+++ b/Assets/Code/_Common/RayCaster.cs
@@ -6,11 +6,18 @@ namespace PQ.Common
     /*
     Provides a streamlined interface for casting lines from specific points or colliders.
     */
-    public class RayCaster
+    public sealed class RayCaster
     {
         public float     MaxDistance      { get; set; } = Mathf.Infinity;
         public LayerMask LayerMask        { get; set; } = ~0;
         public bool      DrawCastInEditor { get; set; } = true;
+
+        public override string ToString() =>
+            $"{GetType().Name}:{{" +
+                $"distance:{MaxDistance}," +
+                $"layerMask:{LayerMask}," +
+                $"drawCastInEditor:{DrawCastInEditor}}}";
+
 
         public RayCaster() { }
 

--- a/Assets/Code/_Common/RayCaster.cs
+++ b/Assets/Code/_Common/RayCaster.cs
@@ -8,8 +8,9 @@ namespace PQ.Common
     */
     public class RayCaster
     {
-        public float     MaxDistance { get; set; } = Mathf.Infinity;
-        public LayerMask LayerMask   { get; set; } = ~0;
+        public float     MaxDistance      { get; set; } = Mathf.Infinity;
+        public LayerMask LayerMask        { get; set; } = ~0;
+        public bool      DrawCastInEditor { get; set; } = true;
 
         public RayCaster() { }
 
@@ -34,9 +35,15 @@ namespace PQ.Common
         }
 
 
-        private static RayHit? Cast(Vector2 origin, Vector2 direction, float distance, LayerMask layerMask)
+        private RayHit? Cast(Vector2 origin, Vector2 direction, float distance, LayerMask layerMask)
         {
             RaycastHit2D castHit2D = Physics2D.Raycast(origin, direction, distance, layerMask);
+
+            #if UNITY_EDITOR
+            if (DrawCastInEditor)
+                DrawCastResultAsLineInEditor(origin, direction, distance, castHit2D);
+            #endif
+
             if (!castHit2D)
             {
                 return null;
@@ -50,11 +57,32 @@ namespace PQ.Common
             );
         }
 
+
         private static Vector2 FindPositionOnColliderEdgeInGivenDirection(Collider2D collider, Vector2 direction)
         {
             Vector2 center = collider.bounds.center;
             collider.bounds.IntersectRay(new Ray(center, direction), out float distanceFromCenterToEdge);
             return center - (distanceFromCenterToEdge * direction);
         }
+        
+        #if UNITY_EDITOR
+        private static void DrawCastResultAsLineInEditor(Vector2 origin, Vector2 direction, float distance, RaycastHit2D hit)
+        {
+            Color color;
+            Vector2 terminal;
+            if (hit)
+            {
+                color = Color.green;
+                terminal = hit.point;
+            }
+            else
+            {
+                color = Color.red;
+                terminal = origin + distance * direction;
+            }
+
+            Debug.DrawLine(origin, terminal, color, duration: Time.deltaTime);
+        }
+        #endif
     }
 }

--- a/Assets/Code/_Common/RayCasterBox.cs
+++ b/Assets/Code/_Common/RayCasterBox.cs
@@ -65,6 +65,7 @@ namespace PQ.Common
             _frontSensor  = new();
             _bottomSensor = new();
             _topSensor    = new();
+            _hasAnySpacingChanged = true;
         }
 
         void Start()

--- a/Assets/Code/_Common/RayCasterBox.cs
+++ b/Assets/Code/_Common/RayCasterBox.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using PQ.Common.Extensions;
 
 
 namespace PQ.Common
@@ -10,30 +9,16 @@ namespace PQ.Common
     For example, is there something X distance in front of me?
     What about the front half of the box's bottom side?
     */
-    public class RayCasterBox : MonoBehaviour
+    public sealed class RayCasterBox
     {
         private Vector2 _center;
         private Vector2 _xAxis;
         private Vector2 _yAxis;
-        private KinematicBody2D _physicsBody;
+        private KinematicBody2D _body;
         private RayCasterSegment _backSensor;
         private RayCasterSegment _frontSensor;
         private RayCasterSegment _bottomSensor;
         private RayCasterSegment _topSensor;
-
-        private bool _hasAnySpacingChanged;
-        private float _backRaySpacing;
-        private float _frontRaySpacing;
-        private float _bottomRaySpacing;
-        private float _topRaySpacing;
-        private void SetSpacing(ref float field, float value)
-        {
-            if (!Mathf.Approximately(field, value))
-            {
-                field = value;
-                _hasAnySpacingChanged = true;
-            }
-        }
 
         public struct Result
         {
@@ -46,11 +31,45 @@ namespace PQ.Common
                 this.hitDistance = hitDistance;
             }
         }
+        
+        
+        public Vector2 Center      => _center;
+        public Vector2 ForwardAxis => _xAxis;
+        public Vector2 UpAxis      => _yAxis;
 
-        public float BackSensorSpacing   { get => _backRaySpacing;   set => SetSpacing(ref _backRaySpacing,   value); }
-        public float FrontSensorSpacing  { get => _frontRaySpacing;  set => SetSpacing(ref _frontRaySpacing,  value); }
-        public float BottomSensorSpacing { get => _bottomRaySpacing; set => SetSpacing(ref _bottomRaySpacing, value); }
-        public float TopSensorSpacing    { get => _topRaySpacing;    set => SetSpacing(ref _topRaySpacing,    value); }
+        public (Vector2, Vector2) BackSide   => (_backSensor.SegmentStart,   _backSensor.SegmentEnd);
+        public (Vector2, Vector2) FrontSide  => (_frontSensor.SegmentStart,  _frontSensor.SegmentEnd);
+        public (Vector2, Vector2) BottomSide => (_bottomSensor.SegmentStart, _bottomSensor.SegmentEnd);
+        public (Vector2, Vector2) TopSide    => (_topSensor.SegmentStart,    _topSensor.SegmentEnd);
+
+        public override string ToString() =>
+            $"{GetType().Name}{{" +
+                $"Back{_backSensor}, " +
+                $"Front{_frontSensor}, " +
+                $"Bottom{_bottomSensor}, " +
+                $"Top{_topSensor}}}";
+
+
+        public RayCasterBox(KinematicBody2D body)
+        {
+            _body = body;
+            _backSensor   = new();
+            _frontSensor  = new();
+            _bottomSensor = new();
+            _topSensor    = new();
+        }
+
+        public void SetBehindRayCount(int rayCount) => _backSensor.SetRayCount(rayCount);
+        public void SetFrontRayCount(int rayCount)  => _frontSensor.SetRayCount(rayCount);
+        public void SetBelowRayCount(int rayCount)  => _bottomSensor.SetRayCount(rayCount);
+        public void SetAboveRayCount(int rayCount)  => _topSensor.SetRayCount(rayCount);
+        public void SetAllRayCounts(int rayCount)
+        {
+            _backSensor  .SetRayCount(rayCount);
+            _frontSensor .SetRayCount(rayCount);
+            _bottomSensor.SetRayCount(rayCount);
+            _topSensor   .SetRayCount(rayCount);
+        }
 
         public Result CheckBehind(LayerMask target, float distance) => Cast(_backSensor,   target, distance);
         public Result CheckFront(LayerMask target,  float distance) => Cast(_frontSensor,  target, distance);
@@ -58,49 +77,23 @@ namespace PQ.Common
         public Result CheckBelow(LayerMask target,  float distance) => Cast(_bottomSensor, target, distance);
 
 
-        void Awake()
-        {
-            _physicsBody = gameObject.GetComponent<KinematicBody2D>();
-            _backSensor   = new();
-            _frontSensor  = new();
-            _bottomSensor = new();
-            _topSensor    = new();
-            _hasAnySpacingChanged = true;
-        }
-
-        void Start()
-        {
-            UpdateAll();
-        }
-
-        void Update()
-        {
-            UpdateAll();
-        }
-
         private Result Cast(RayCasterSegment caster, LayerMask layerMask, float distanceToCast)
         {
             // todo: properly compute actual results, and add result/standard-deviation/etc functionality
-            caster.UpdateCastOptions(layerMask, distanceToCast);
-            caster.CastAll();
+            UpdateBounds();
+
+            caster.Cast(layerMask, distanceToCast);
             var results = caster.RayCastResults;
             return new Result(hitPercentage: 0.50f, hitDistance: 0.25f);
         }
 
-        private void UpdateAll()
+        private void UpdateBounds()
         {
-            SetBounds(
-                center: _physicsBody.Position,
-                xAxis:  _physicsBody.BoundExtents.x * _physicsBody.Forward,
-                yAxis:  _physicsBody.BoundExtents.y * _physicsBody.Up);
-        }
+            Vector2 center = _body.Position;
+            Vector2 xAxis  = _body.BoundExtents.x * _body.Forward;
+            Vector2 yAxis  = _body.BoundExtents.y * _body.Up;
 
-        private void SetBounds(Vector2 center, Vector2 xAxis, Vector2 yAxis)
-        {
-            // since change in bounds or ray spacing can result in different ray counts,
-            // only update updating positioning when we have to
-            if (!_hasAnySpacingChanged &&
-                center == _center &&
+            if (center == _center &&
                 Mathf.Approximately(xAxis.x, _xAxis.x) && Mathf.Approximately(xAxis.y, _xAxis.y) &&
                 Mathf.Approximately(yAxis.x, _yAxis.x) && Mathf.Approximately(yAxis.y, _yAxis.y))
             {
@@ -117,35 +110,10 @@ namespace PQ.Common
             _center = center;
             _xAxis  = xAxis;
             _yAxis  = yAxis;
-            _hasAnySpacingChanged = false;
-            _backSensor  .UpdateCastDirection(-xAxis);
-            _frontSensor .UpdateCastDirection( xAxis);
-            _bottomSensor.UpdateCastDirection(-yAxis);
-            _topSensor   .UpdateCastDirection( yAxis);
-            _backSensor  .UpdatePositioning(rearBottom,  rearTop,     _backRaySpacing);
-            _frontSensor .UpdatePositioning(frontBottom, frontTop,    _frontRaySpacing);
-            _bottomSensor.UpdatePositioning(rearBottom,  frontBottom, _bottomRaySpacing);
-            _topSensor   .UpdatePositioning(rearTop,     frontTop,    _topRaySpacing);
+            _backSensor  .UpdatePositioning(segmentStart: rearBottom,  segmentEnd: rearTop,     rayDirection: -xAxis);
+            _frontSensor .UpdatePositioning(segmentStart: frontBottom, segmentEnd: frontTop,    rayDirection:  xAxis);
+            _bottomSensor.UpdatePositioning(segmentStart: rearBottom,  segmentEnd: frontBottom, rayDirection: -yAxis);
+            _topSensor   .UpdatePositioning(segmentStart: rearTop,     segmentEnd: frontTop,    rayDirection:  yAxis);
         }
-
-        #if UNITY_EDITOR
-        void OnDrawGizmos()
-        {
-            if (!Application.IsPlaying(this) || !enabled)
-            {
-                return;
-            }
-
-            // draw a bounding box that should be identical to the BoxCollider2D bounds in the editor window
-            GizmoExtensions.DrawLine(_backSensor  .SegmentStart, _backSensor  .SegmentEnd, Color.gray);
-            GizmoExtensions.DrawLine(_frontSensor .SegmentStart, _frontSensor .SegmentEnd, Color.gray);
-            GizmoExtensions.DrawLine(_bottomSensor.SegmentStart, _bottomSensor.SegmentEnd, Color.gray);
-            GizmoExtensions.DrawLine(_topSensor   .SegmentStart, _topSensor   .SegmentEnd, Color.gray);
-
-            // draw a pair of arrows from the that should be identical to the transform's axes in the editor window
-            GizmoExtensions.DrawArrow(from: _center, to: _center + _xAxis, color: Color.red);
-            GizmoExtensions.DrawArrow(from: _center, to: _center + _yAxis, color: Color.green);
-        }
-        #endif
     }
 }

--- a/Assets/Code/_Common/RayCasterSegment.cs
+++ b/Assets/Code/_Common/RayCasterSegment.cs
@@ -108,6 +108,7 @@ namespace PQ.Common
         {
             for (int rayIndex = 0; rayIndex < _results.Length; rayIndex++)
             {
+                Debug.Log($"segment.cast[{rayIndex}]");
                 Cast(rayIndex);
             }
         }

--- a/Assets/Code/_Common/_Extensions/GizmoExtensions.cs
+++ b/Assets/Code/_Common/_Extensions/GizmoExtensions.cs
@@ -29,12 +29,12 @@ namespace PQ.Common.Extensions
         }
 
         /* Draw line between given world positions. */
-        public static void DrawLine(Vector2 from, Vector2 to, Color? color = null)
+        public static void DrawLine((Vector2, Vector2) endpoints, Color? color = null)
         {
             Color previousColor = Gizmos.color;
             Gizmos.color = color.GetValueOrDefault(DEFAULT_COLOR);
 
-            Gizmos.DrawLine(from, to);
+            Gizmos.DrawLine(endpoints.Item1, endpoints.Item2);
 
             Gizmos.color = previousColor;
         }

--- a/Assets/Prefabs/Penguin.prefab
+++ b/Assets/Prefabs/Penguin.prefab
@@ -263,7 +263,6 @@ GameObject:
   - component: {fileID: 4753795910216235721}
   - component: {fileID: 7859832108952071242}
   - component: {fileID: 2138608317391900897}
-  - component: {fileID: 844064212498705148}
   - component: {fileID: 331518940653301218}
   - component: {fileID: 1728887597599890734}
   - component: {fileID: 4753795910216235732}
@@ -368,18 +367,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a28484ee5f1151f4dae5545688b2f5ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &844064212498705148
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4753795910216235740}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ce58fd52abec0ba498285837d34f864d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &331518940653301218
@@ -3158,12 +3145,12 @@ PrefabInstance:
     - target: {fileID: -3794450590055754063, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: -0.04060197
+      value: -0.040602088
       objectReference: {fileID: 0}
     - target: {fileID: -3794450590055754063, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -0.00027132034
+      value: -0.00027227402
       objectReference: {fileID: 0}
     - target: {fileID: -3794450590055754063, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -3178,7 +3165,7 @@ PrefabInstance:
     - target: {fileID: -3794450590055754063, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 6.518942
+      value: 6.518941
       objectReference: {fileID: 0}
     - target: {fileID: -3794450590055754063, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -3193,7 +3180,7 @@ PrefabInstance:
     - target: {fileID: -3747871290231385253, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 0.00033405423
+      value: 0.00033214688
       objectReference: {fileID: 0}
     - target: {fileID: -3747871290231385253, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -3583,7 +3570,7 @@ PrefabInstance:
     - target: {fileID: -1635405638250097474, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 0.008960485
+      value: 0.008960009
       objectReference: {fileID: 0}
     - target: {fileID: -1635405638250097474, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -3598,7 +3585,7 @@ PrefabInstance:
     - target: {fileID: -1635405638250097474, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 3.0099928
+      value: 3.0099926
       objectReference: {fileID: 0}
     - target: {fileID: -1635405638250097474, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -3713,7 +3700,7 @@ PrefabInstance:
     - target: {fileID: -367189196566187402, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: -0.010268211
+      value: -0.01026845
       objectReference: {fileID: 0}
     - target: {fileID: -367189196566187402, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -3758,7 +3745,7 @@ PrefabInstance:
     - target: {fileID: -135927049809428613, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -0.014393806
+      value: -0.01439333
       objectReference: {fileID: 0}
     - target: {fileID: -135927049809428613, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -3773,7 +3760,7 @@ PrefabInstance:
     - target: {fileID: -135927049809428613, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 5.6695604
+      value: 5.669561
       objectReference: {fileID: 0}
     - target: {fileID: -135927049809428613, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -4108,7 +4095,7 @@ PrefabInstance:
     - target: {fileID: 2968873228828792482, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 0.08893752
+      value: 0.08893728
       objectReference: {fileID: 0}
     - target: {fileID: 2968873228828792482, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -4123,7 +4110,7 @@ PrefabInstance:
     - target: {fileID: 2968873228828792482, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 2.9305832
+      value: 2.9305835
       objectReference: {fileID: 0}
     - target: {fileID: 2968873228828792482, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
@@ -4243,7 +4230,7 @@ PrefabInstance:
     - target: {fileID: 3318685223035392496, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: -0.0031120777
+      value: -0.0031123161
       objectReference: {fileID: 0}
     - target: {fileID: 3318685223035392496, guid: c9587e548613a564c81ba23ebf263460,
         type: 3}

--- a/Assets/Scenes/Test_Minimal/Player_Block.prefab
+++ b/Assets/Scenes/Test_Minimal/Player_Block.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 1001543055492729391}
   - component: {fileID: 4765852279069534298}
   - component: {fileID: 6424954451660586289}
-  - component: {fileID: -6384245666304517564}
   - component: {fileID: 1743938938977150192}
   - component: {fileID: 1106268956338744581}
   m_Layer: 9
@@ -147,18 +146,6 @@ MonoBehaviour:
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a28484ee5f1151f4dae5545688b2f5ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &-6384245666304517564
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3204818302733060367}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ce58fd52abec0ba498285837d34f864d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &1743938938977150192

--- a/Assets/Scenes/Test_Minimal/RectEntity.cs
+++ b/Assets/Scenes/Test_Minimal/RectEntity.cs
@@ -22,10 +22,6 @@ namespace PQ.TestScenes.Minimal
             _controller.Settings = _characterSettings;
         }
 
-        void Start()
-        {
-        }
-
         void OnEnable()
         {
             _eventCenter.jumpCommand.AddListener(OnJump);

--- a/Assets/Scenes/Test_Minimal/RectMovementController.cs
+++ b/Assets/Scenes/Test_Minimal/RectMovementController.cs
@@ -34,7 +34,7 @@ namespace PQ.TestScenes.Minimal
 
         void Awake()
         {
-            _body    = gameObject.GetComponent<KinematicBody2D>();
+            _body   = gameObject.GetComponent<KinematicBody2D>();
             _caster = gameObject.GetComponent<RayCasterBox>();
         }
 

--- a/Assets/Scenes/Test_Minimal/RectMovementController.cs
+++ b/Assets/Scenes/Test_Minimal/RectMovementController.cs
@@ -35,7 +35,7 @@ namespace PQ.TestScenes.Minimal
         void Awake()
         {
             _body   = gameObject.GetComponent<KinematicBody2D>();
-            _caster = gameObject.GetComponent<RayCasterBox>();
+            _caster = new RayCasterBox(_body);
         }
 
         void Start()

--- a/Assets/Scenes/Test_Minimal/RectMovementController.cs
+++ b/Assets/Scenes/Test_Minimal/RectMovementController.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 using PQ.Common;
 using PQ.Entities;
@@ -8,24 +7,25 @@ namespace PQ.TestScenes.Minimal
 {
     public class RectMovementController : MonoBehaviour
     {
-        private RayCasterBox _collisionChecker;
-        private KinematicBody2D _physicsBody2D;
+        private RayCasterBox _caster;
+        private KinematicBody2D _body;
 
-        public event Action<bool> GroundContactChanged;
+        private bool _isGrounded;
+
+        public Vector2 Position => _body.Position;
         public Character2DSettings Settings { get; set; }
 
-        public Vector2 Position => _physicsBody2D.Position;
         public void PlaceAt(Vector2 position, float rotation)
         {
-            _physicsBody2D.MoveTo(position);
-            _physicsBody2D.SetLocalOrientation3D(0, 0, rotation);
+            _body.MoveTo(position);
+            _body.SetLocalOrientation3D(0, 0, rotation);
         }
-        public void FaceRight() => _physicsBody2D.SetLocalOrientation3D(0, 0, 0);
-        public void FaceLeft() => _physicsBody2D.SetLocalOrientation3D(0, 180, 0);
+        public void FaceRight() => _body.SetLocalOrientation3D(0, 0, 0);
+        public void FaceLeft()  => _body.SetLocalOrientation3D(0, 180, 0);
         public void MoveForward()
         {
             float distanceToMove = Settings.HorizontalMovementPeakSpeed * Time.fixedDeltaTime;
-            _physicsBody2D.MoveBy(distanceToMove * _physicsBody2D.Forward);
+            _body.MoveBy(distanceToMove * _body.Forward);
         }
         public void Jump()
         {
@@ -34,18 +34,36 @@ namespace PQ.TestScenes.Minimal
 
         void Awake()
         {
-            _physicsBody2D    = gameObject.GetComponent<KinematicBody2D>();
-            _collisionChecker = gameObject.GetComponent<RayCasterBox>();
+            _body    = gameObject.GetComponent<KinematicBody2D>();
+            _caster = gameObject.GetComponent<RayCasterBox>();
         }
 
         void Start()
         {
-
+            UpdateGroundContactInfo(force: true);
         }
 
         void FixedUpdate()
         {
+            UpdateGroundContactInfo();
 
+            if (!_isGrounded)
+            {
+                _body.MoveBy(Settings.GravityStrength * Vector2.down);
+            }
+        }
+
+
+        private void UpdateGroundContactInfo(bool force = false)
+        {
+            // todo: use a scriptable object or something for these checks
+            var result = _caster.CheckBelow(target: LayerMask.GetMask("Platform"), distance: int.MaxValue);
+            bool isInContactWithGround = result.hitPercentage >= 0.50f && result.hitDistance <= 0.25f;
+
+            if (_isGrounded != isInContactWithGround || force)
+            {
+                _isGrounded = isInContactWithGround;
+            }
         }
     }
 }


### PR DESCRIPTION
# Fixing and simplifying ray casting
## Overview
### Summary
Streamlines caster classes and makes them more robust - and thus both easier to use and more accurate in results.

### Background
Before, ray casts weren't exactly the most robust (lacking some corner case null checks, ray spacing was wrong for minimum ray count, etc).

Also, ray caster classes were fairly ad-hoc and lacked cohesion. For example, `BoxCaster` was a monobehavior while the single and segment casters were not.

Furthermore, the ray cast results array was often reallocated due to small changes in segment length (since the number of rays to cast for a given segment were determined according to the spacing between ray origins, so for small gaps it would often reallocate everything!).


### Solution
* Always have at least 3 ray casts per box side
* Rely on explicitly provided ray counts to avoid uneeded memory allocations
* Greatly reduce the amount of cached state to avoid synchronization issues
* Remove unused/deadcode in casters/controllers
* Provide more reasonable defaults so things work more as expected out of the box
* Add futher logging/exceptions for catching caster issues earlier

### Detailed Changelog
* Integrates new casters into character controllers
* Moves gizmo drawing from `RayCasterBox` into `Character2D`
* Remove unused character controller setting fields for thresholds that no longer apply due to switch to kinematic controls

* Clean up representation of each caster's `ToString()` to be more consistent and helpful
* Add on-by-default drawing of any ray cast in editor unless explicitly turned off or running outside Unity
* Modify signature of `GizmosExtensions.DrawLine()` such that a tuple of the line's endpoints are taken as arguments instead

* Exposes endpoints of each side in `RayCasterBox` as properties
* Restructure `RayCasterBox` such that bounds and ray counts are updated seperately from cast parameters like distance
* Convert monobehavior `RayCasterBox` to a normal C# class such that it's consistent with the other `RayCaster` classes
* Replace `RayCasterBox`'s ray spacing functionality with methods for settings ray counts
* Add convenience methods to `RayCasterBox` for performing cast from a specific side (eg `CheckBelow`)

* Remove `RayCasterSegment.UpdateCastOptions()`  such that `layerMask` and `distance` are passed in to `Cast` instead
* Remove `RayCasterSegment.UpdateCastDirection()`  such that it's passed into `UpdatePositioning()` instead
* Extract out new `RayCasterSegment.SetRayCount()` method for resizing the number of origins explitly
* Consolidate all internal state in `RayCasterSegment` into just endpoints, ray direction, caster, and results
* Rewrite `RayCasterSegment`'s API method docs to make things extra clear



## Screenshots
### On Belly
![lying-down](https://user-images.githubusercontent.com/8084757/188321369-a17376b3-b6d3-4011-8f62-bedc0f2dc897.png)

### On Feet
![after-standing-back-up](https://user-images.githubusercontent.com/8084757/188321385-c71e62a2-79c4-4d95-9097-6e067cf307f8.png)