### PR TITLE
Kinematic Part 6: Simplifying ray cast results

### DIFF
--- a/Assets/Code/Entities/Character2D.cs
+++ b/Assets/Code/Entities/Character2D.cs
@@ -63,9 +63,15 @@ namespace PQ.Entities
                 return;
             }
 
-            // todo: use a scriptable object or something for these checks
-            var result = _caster.CheckBelow(target: LayerMask.GetMask("Platform"), distance: int.MaxValue);
-            bool isInContactWithGround = result.hitPercentage >= 0.50f && result.hitDistance <= 0.25f;
+            // todo: use a scriptable object or something for these variables
+            var groundLayer = LayerMask.GetMask("Platform");
+            var groundDistanceToCheck   = 5.00f;
+            var groundDistanceTolerated = 0.25f;
+
+            var result = _caster.CheckBelow(target: groundLayer, groundDistanceToCheck);
+            bool isInContactWithGround =
+                result.hitPercentage >= 0.50f &&
+                result.hitDistance <= groundDistanceTolerated;
 
             if (_isGrounded != isInContactWithGround || force)
             {

--- a/Assets/Code/_Common/RayCaster.cs
+++ b/Assets/Code/_Common/RayCaster.cs
@@ -23,26 +23,26 @@ namespace PQ.Common
 
 
         /* Shoot out a line between given points, seeing if a TargetLayer is hit. */
-        public RayHit? CastBetween(Vector2 from, Vector2 to)
+        public RayHit CastBetween(Vector2 from, Vector2 to)
         {
             return Cast(from, (to - from).normalized, MaxDistance, LayerMask);
         }
 
         /* Shoot out a line from point to max distance from that point until a TargetLayer is hit. */
-        public RayHit? CastFromPoint(Vector2 point, Vector2 direction)
+        public RayHit CastFromPoint(Vector2 point, Vector2 direction)
         {
             return Cast(point, direction, MaxDistance, LayerMask);
         }
 
         /* Shoot out a line from edge of collider to distance from that point until a TargetLayer is hit. */
-        public RayHit? CastFromCollider(Collider2D collider, Vector2 direction)
+        public RayHit CastFromCollider(Collider2D collider, Vector2 direction)
         {
             Vector2 point = FindPositionOnColliderEdgeInGivenDirection(collider, direction);
             return Cast(point, direction, MaxDistance, LayerMask);
         }
 
 
-        private RayHit? Cast(Vector2 origin, Vector2 direction, float distance, LayerMask layerMask)
+        private RayHit Cast(Vector2 origin, Vector2 direction, float distance, LayerMask layerMask)
         {
             RaycastHit2D castHit2D = Physics2D.Raycast(origin, direction, distance, layerMask);
 
@@ -53,7 +53,7 @@ namespace PQ.Common
 
             if (!castHit2D)
             {
-                return null;
+                return default;
             }
 
             return new RayHit(

--- a/Assets/Code/_Common/RayCaster.cs
+++ b/Assets/Code/_Common/RayCaster.cs
@@ -75,20 +75,20 @@ namespace PQ.Common
         #if UNITY_EDITOR
         private static void DrawCastResultAsLineInEditor(Vector2 origin, Vector2 direction, float distance, RaycastHit2D hit)
         {
-            Color color;
-            Vector2 terminal;
+            float duration = Time.deltaTime;
+            Vector2 terminal = origin + distance * direction;
+
             if (hit)
             {
-                color = Color.green;
-                terminal = hit.point;
+                // draw the ray past the hit point all the way to max distance,
+                // making optimization easier since excessively long cast distance becomes obvious
+                Debug.DrawLine(origin, hit.point, Color.green, duration);
+                Debug.DrawLine(hit.point, terminal, Color.red, duration);
             }
             else
             {
-                color = Color.red;
-                terminal = origin + distance * direction;
+                Debug.DrawLine(origin, terminal, Color.red, duration);
             }
-
-            Debug.DrawLine(origin, terminal, color, duration: Time.deltaTime);
         }
         #endif
     }

--- a/Assets/Code/_Common/RayCasterBox.cs
+++ b/Assets/Code/_Common/RayCasterBox.cs
@@ -66,15 +66,11 @@ namespace PQ.Common
 
         private RayHitGroup Cast(RayCasterSegment caster, LayerMask layerMask, float distanceToCast)
         {
-            // todo: properly compute actual results, and add result/standard-deviation/etc functionality
-            UpdateBounds();
-
-            caster.Cast(layerMask, distanceToCast);
-            var results = caster.RayCastResults;
-            return new RayHitGroup(hitPercentage: 0.50f, hitDistance: 0.25f);
+            UpdateBoundsIfChanged();
+            return caster.Cast(layerMask, distanceToCast);
         }
 
-        private void UpdateBounds()
+        private void UpdateBoundsIfChanged()
         {
             Vector2 center = _body.Position;
             Vector2 xAxis  = _body.BoundExtents.x * _body.Forward;

--- a/Assets/Code/_Common/RayCasterBox.cs
+++ b/Assets/Code/_Common/RayCasterBox.cs
@@ -15,52 +15,52 @@ namespace PQ.Common
         private Vector2 _xAxis;
         private Vector2 _yAxis;
         private KinematicBody2D _body;
-        private RayCasterSegment _backSensor;
-        private RayCasterSegment _frontSensor;
+        private RayCasterSegment _backCaster;
+        private RayCasterSegment _frontCaster;
         private RayCasterSegment _bottomSensor;
-        private RayCasterSegment _topSensor;
-                
+        private RayCasterSegment _topCaster;
+
         public Vector2 Center      => _center;
         public Vector2 ForwardAxis => _xAxis;
         public Vector2 UpAxis      => _yAxis;
 
-        public (Vector2, Vector2) BackSide   => (_backSensor.SegmentStart,   _backSensor.SegmentEnd);
-        public (Vector2, Vector2) FrontSide  => (_frontSensor.SegmentStart,  _frontSensor.SegmentEnd);
+        public (Vector2, Vector2) BackSide   => (_backCaster.SegmentStart,   _backCaster.SegmentEnd);
+        public (Vector2, Vector2) FrontSide  => (_frontCaster.SegmentStart,  _frontCaster.SegmentEnd);
         public (Vector2, Vector2) BottomSide => (_bottomSensor.SegmentStart, _bottomSensor.SegmentEnd);
-        public (Vector2, Vector2) TopSide    => (_topSensor.SegmentStart,    _topSensor.SegmentEnd);
+        public (Vector2, Vector2) TopSide    => (_topCaster.SegmentStart,    _topCaster.SegmentEnd);
 
         public override string ToString() =>
             $"{GetType().Name}{{" +
-                $"Back{_backSensor}, " +
-                $"Front{_frontSensor}, " +
+                $"Back{_backCaster}, " +
+                $"Front{_frontCaster}, " +
                 $"Bottom{_bottomSensor}, " +
-                $"Top{_topSensor}}}";
+                $"Top{_topCaster}}}";
 
 
         public RayCasterBox(KinematicBody2D body)
         {
             _body = body;
-            _backSensor   = new();
-            _frontSensor  = new();
+            _backCaster   = new();
+            _frontCaster  = new();
             _bottomSensor = new();
-            _topSensor    = new();
+            _topCaster    = new();
         }
 
-        public void SetBehindRayCount(int rayCount) => _backSensor.SetRayCount(rayCount);
-        public void SetFrontRayCount(int rayCount)  => _frontSensor.SetRayCount(rayCount);
+        public void SetBehindRayCount(int rayCount) => _backCaster.SetRayCount(rayCount);
+        public void SetFrontRayCount(int rayCount)  => _frontCaster.SetRayCount(rayCount);
         public void SetBelowRayCount(int rayCount)  => _bottomSensor.SetRayCount(rayCount);
-        public void SetAboveRayCount(int rayCount)  => _topSensor.SetRayCount(rayCount);
+        public void SetAboveRayCount(int rayCount)  => _topCaster.SetRayCount(rayCount);
         public void SetAllRayCounts(int rayCount)
         {
-            _backSensor  .SetRayCount(rayCount);
-            _frontSensor .SetRayCount(rayCount);
+            _backCaster  .SetRayCount(rayCount);
+            _frontCaster .SetRayCount(rayCount);
             _bottomSensor.SetRayCount(rayCount);
-            _topSensor   .SetRayCount(rayCount);
+            _topCaster   .SetRayCount(rayCount);
         }
 
-        public RayHitGroup CheckBehind(LayerMask target, float distance) => Cast(_backSensor,   target, distance);
-        public RayHitGroup CheckFront(LayerMask target,  float distance) => Cast(_frontSensor,  target, distance);
-        public RayHitGroup CheckAbove(LayerMask target,  float distance) => Cast(_topSensor,    target, distance);
+        public RayHitGroup CheckBehind(LayerMask target, float distance) => Cast(_backCaster,   target, distance);
+        public RayHitGroup CheckFront(LayerMask target,  float distance) => Cast(_frontCaster,  target, distance);
+        public RayHitGroup CheckAbove(LayerMask target,  float distance) => Cast(_topCaster,    target, distance);
         public RayHitGroup CheckBelow(LayerMask target,  float distance) => Cast(_bottomSensor, target, distance);
 
 
@@ -93,10 +93,10 @@ namespace PQ.Common
             _center = center;
             _xAxis  = xAxis;
             _yAxis  = yAxis;
-            _backSensor  .UpdatePositioning(segmentStart: rearBottom,  segmentEnd: rearTop,     rayDirection: -xAxis);
-            _frontSensor .UpdatePositioning(segmentStart: frontBottom, segmentEnd: frontTop,    rayDirection:  xAxis);
+            _backCaster  .UpdatePositioning(segmentStart: rearBottom,  segmentEnd: rearTop,     rayDirection: -xAxis);
+            _frontCaster .UpdatePositioning(segmentStart: frontBottom, segmentEnd: frontTop,    rayDirection:  xAxis);
             _bottomSensor.UpdatePositioning(segmentStart: rearBottom,  segmentEnd: frontBottom, rayDirection: -yAxis);
-            _topSensor   .UpdatePositioning(segmentStart: rearTop,     segmentEnd: frontTop,    rayDirection:  yAxis);
+            _topCaster   .UpdatePositioning(segmentStart: rearTop,     segmentEnd: frontTop,    rayDirection:  yAxis);
         }
     }
 }

--- a/Assets/Code/_Common/RayCasterBox.cs
+++ b/Assets/Code/_Common/RayCasterBox.cs
@@ -19,20 +19,7 @@ namespace PQ.Common
         private RayCasterSegment _frontSensor;
         private RayCasterSegment _bottomSensor;
         private RayCasterSegment _topSensor;
-
-        public struct Result
-        {
-            public readonly float hitPercentage;
-            public readonly float hitDistance;
-
-            public Result(float hitPercentage, float hitDistance)
-            {
-                this.hitPercentage = hitPercentage;
-                this.hitDistance = hitDistance;
-            }
-        }
-        
-        
+                
         public Vector2 Center      => _center;
         public Vector2 ForwardAxis => _xAxis;
         public Vector2 UpAxis      => _yAxis;
@@ -71,20 +58,20 @@ namespace PQ.Common
             _topSensor   .SetRayCount(rayCount);
         }
 
-        public Result CheckBehind(LayerMask target, float distance) => Cast(_backSensor,   target, distance);
-        public Result CheckFront(LayerMask target,  float distance) => Cast(_frontSensor,  target, distance);
-        public Result CheckAbove(LayerMask target,  float distance) => Cast(_topSensor,    target, distance);
-        public Result CheckBelow(LayerMask target,  float distance) => Cast(_bottomSensor, target, distance);
+        public RayHitGroup CheckBehind(LayerMask target, float distance) => Cast(_backSensor,   target, distance);
+        public RayHitGroup CheckFront(LayerMask target,  float distance) => Cast(_frontSensor,  target, distance);
+        public RayHitGroup CheckAbove(LayerMask target,  float distance) => Cast(_topSensor,    target, distance);
+        public RayHitGroup CheckBelow(LayerMask target,  float distance) => Cast(_bottomSensor, target, distance);
 
 
-        private Result Cast(RayCasterSegment caster, LayerMask layerMask, float distanceToCast)
+        private RayHitGroup Cast(RayCasterSegment caster, LayerMask layerMask, float distanceToCast)
         {
             // todo: properly compute actual results, and add result/standard-deviation/etc functionality
             UpdateBounds();
 
             caster.Cast(layerMask, distanceToCast);
             var results = caster.RayCastResults;
-            return new Result(hitPercentage: 0.50f, hitDistance: 0.25f);
+            return new RayHitGroup(hitPercentage: 0.50f, hitDistance: 0.25f);
         }
 
         private void UpdateBounds()

--- a/Assets/Code/_Common/RayCasterSegment.cs
+++ b/Assets/Code/_Common/RayCasterSegment.cs
@@ -78,7 +78,6 @@ namespace PQ.Common
         /* In the same direction, cast out rays from each origin along the segment with given options. */
         public RayHitGroup Cast(LayerMask layerMask, float maxDistance)
         {
-            RayHitGroup hitGroup = default;
             Vector2 offsetBetweenRays = RaySpacing * SegmentDirection;
             if (offsetBetweenRays == Vector2.zero)
             {
@@ -88,14 +87,27 @@ namespace PQ.Common
 
             _rayCaster.LayerMask = layerMask;
             _rayCaster.MaxDistance = maxDistance;
-            for (int rayIndex = 0; rayIndex < _results.Length; rayIndex++)
+
+            int hitCount = 0;
+            int castCount = _results.Length;
+            float distanceSum = 0;
+            for (int rayIndex = 0; rayIndex < castCount; rayIndex++)
             {
                 Vector2 rayOrigin = _segmentStart + (rayIndex * offsetBetweenRays);
-                _results[rayIndex] = _rayCaster.CastFromPoint(rayOrigin, _rayDirection);
+                var hit = _rayCaster.CastFromPoint(rayOrigin, _rayDirection);
+                if (hit)
+                {
+                    hitCount++;
+                    distanceSum += hit.distance;
+                }
+
+                _results[rayIndex] = hit;
             }
 
-            // todo: properly compute actual results, and add result/standard-deviation/etc functionality
-            return hitGroup;
+            return new RayHitGroup(
+                hitPercentage: castCount / (float)hitCount,
+                hitDistance:   castCount / (float)distanceSum
+            );
         }
     }
 }

--- a/Assets/Code/_Common/RayCasterSegment.cs
+++ b/Assets/Code/_Common/RayCasterSegment.cs
@@ -93,6 +93,8 @@ namespace PQ.Common
                 Vector2 rayOrigin = _segmentStart + (rayIndex * offsetBetweenRays);
                 _results[rayIndex] = _rayCaster.CastFromPoint(rayOrigin, _rayDirection);
             }
+
+            // todo: properly compute actual results, and add result/standard-deviation/etc functionality
             return hitGroup;
         }
     }

--- a/Assets/Code/_Common/RayCasterSegment.cs
+++ b/Assets/Code/_Common/RayCasterSegment.cs
@@ -82,32 +82,20 @@ namespace PQ.Common
             if (offsetBetweenRays == Vector2.zero)
             {
                 Debug.LogWarning($"Insufficient spacing between ray origins {RaySpacing} - skipping casts");
-                return new RayHitGroup(hitPercentage: 0f, hitDistance: 0f);
+                return new RayHitGroup(ReadOnlySpan<RayHit>.Empty);
             }
 
             _rayCaster.LayerMask = layerMask;
             _rayCaster.MaxDistance = maxDistance;
 
-            int hitCount = 0;
             int castCount = _results.Length;
-            float distanceSum = 0;
             for (int rayIndex = 0; rayIndex < castCount; rayIndex++)
             {
                 Vector2 rayOrigin = _segmentStart + (rayIndex * offsetBetweenRays);
-                var hit = _rayCaster.CastFromPoint(rayOrigin, _rayDirection);
-                if (hit)
-                {
-                    hitCount++;
-                    distanceSum += hit.distance;
-                }
-
-                _results[rayIndex] = hit;
+                _results[rayIndex] = _rayCaster.CastFromPoint(rayOrigin, _rayDirection);
             }
 
-            return new RayHitGroup(
-                hitPercentage: castCount / (float)hitCount,
-                hitDistance:   castCount / (float)distanceSum
-            );
+            return new RayHitGroup(_results.AsSpan());
         }
     }
 }

--- a/Assets/Code/_Common/RayCasterSegment.cs
+++ b/Assets/Code/_Common/RayCasterSegment.cs
@@ -14,13 +14,13 @@ namespace PQ.Common
 
         private Vector2 _rayDirection;
         private RayCaster _rayCaster;
-        private RayHit?[] _results;
+        private RayHit[] _results;
 
         public const int MinRayCount = 3;
         public const int MaxRayCount = 1000;
 
 
-        public ReadOnlySpan<RayHit?> RayCastResults => _results.AsSpan();
+        public ReadOnlySpan<RayHit> RayCastResults => _results.AsSpan();
 
         public Vector2   SegmentStart     => _segmentStart;
         public Vector2   SegmentMid       => Vector2.Lerp(_segmentStart, _segmentEnd, 0.50f);
@@ -63,7 +63,7 @@ namespace PQ.Common
 
             if (_results == null || _results.Length != rayCount)
             {
-                _results = new RayHit?[rayCount];
+                _results = new RayHit[rayCount];
             }
         }
 
@@ -76,13 +76,14 @@ namespace PQ.Common
         }
 
         /* In the same direction, cast out rays from each origin along the segment with given options. */
-        public void Cast(LayerMask layerMask, float maxDistance)
+        public RayHitGroup Cast(LayerMask layerMask, float maxDistance)
         {
+            RayHitGroup hitGroup = default;
             Vector2 offsetBetweenRays = RaySpacing * SegmentDirection;
             if (offsetBetweenRays == Vector2.zero)
             {
                 Debug.LogWarning($"Insufficient spacing between ray origins {RaySpacing} - skipping casts");
-                return;
+                return new RayHitGroup(hitPercentage: 0f, hitDistance: 0f);
             }
 
             _rayCaster.LayerMask = layerMask;
@@ -92,6 +93,7 @@ namespace PQ.Common
                 Vector2 rayOrigin = _segmentStart + (rayIndex * offsetBetweenRays);
                 _results[rayIndex] = _rayCaster.CastFromPoint(rayOrigin, _rayDirection);
             }
+            return hitGroup;
         }
     }
 }

--- a/Assets/Code/_Common/RayHit.cs
+++ b/Assets/Code/_Common/RayHit.cs
@@ -10,7 +10,13 @@ namespace PQ.Common
         public readonly Vector2    normal;
         public readonly float      distance;
         public readonly Collider2D collider;
-
+        
+        public override string ToString() =>
+            $"{GetType().Name}:{{" +
+                $"point:{point}," +
+                $"normal:{normal}," +
+                $"distance:{distance}," +
+                $"collider:{collider}}}";
 
         public RayHit(Vector2 point, Vector2 normal, float distance, Collider2D collider)
         {
@@ -19,6 +25,7 @@ namespace PQ.Common
             this.distance = distance;
             this.collider = collider;
         }
+
 
         public static implicit operator bool(RayHit hit)
         {

--- a/Assets/Code/_Common/RayHit.cs
+++ b/Assets/Code/_Common/RayHit.cs
@@ -11,12 +11,18 @@ namespace PQ.Common
         public readonly float      distance;
         public readonly Collider2D collider;
 
+
         public RayHit(Vector2 point, Vector2 normal, float distance, Collider2D collider)
         {
             this.point    = point;
             this.normal   = normal;
             this.distance = distance;
             this.collider = collider;
+        }
+
+        public static implicit operator bool(RayHit hit)
+        {
+            return hit.collider != null;
         }
     }
 }

--- a/Assets/Code/_Common/RayHitGroup.cs
+++ b/Assets/Code/_Common/RayHitGroup.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 
 namespace PQ.Common
@@ -6,17 +7,18 @@ namespace PQ.Common
     /* Results of multiple ray intersections. */
     public struct RayHitGroup
     {
-        public readonly Vector2    point;
-        public readonly Vector2    normal;
-        public readonly float      distance;
-        public readonly Collider2D collider;
+        public readonly float hitPercentage;
+        public readonly float hitDistance;
 
-        public RayHitGroup(Vector2 point, Vector2 normal, float distance, Collider2D collider)
+        public RayHitGroup(float hitPercentage, float hitDistance)
         {
-            this.point    = point;
-            this.normal   = normal;
-            this.distance = distance;
-            this.collider = collider;
+            this.hitPercentage = hitPercentage;
+            this.hitDistance = hitDistance;
+        }
+
+        public static implicit operator bool(RayHitGroup hitGroup)
+        {
+            return Mathf.Approximately(hitGroup.hitPercentage, 0f);
         }
     }
 }

--- a/Assets/Code/_Common/RayHitGroup.cs
+++ b/Assets/Code/_Common/RayHitGroup.cs
@@ -7,18 +7,35 @@ namespace PQ.Common
     /* Results of multiple ray intersections. */
     public struct RayHitGroup
     {
+        public readonly int   rayCount;
+        public readonly int   hitCount;
         public readonly float hitPercentage;
         public readonly float hitDistance;
 
-        public RayHitGroup(float hitPercentage, float hitDistance)
+        // todo: move results _into_ this class, or at least a reference to it
+        public RayHitGroup(ReadOnlySpan<RayHit> hits)
         {
-            this.hitPercentage = hitPercentage;
-            this.hitDistance = hitDistance;
+            int hitCount = 0;
+            float distanceSum = 0f;
+            int rayCount = hits.Length;
+            for (int rayIndex = 0; rayIndex < rayCount; rayIndex++)
+            {
+                if (hits[rayIndex])
+                {
+                    hitCount++;
+                    distanceSum += hits[rayIndex].distance;
+                }
+            }
+
+            this.rayCount      = rayCount;
+            this.hitCount      = hitCount;
+            this.hitPercentage = distanceSum > 0f? ((float)rayCount / hitCount)    : 0f;
+            this.hitDistance   = distanceSum > 0f? ((float)rayCount / distanceSum) : 0f;
         }
 
         public static implicit operator bool(RayHitGroup hitGroup)
         {
-            return hitGroup.hitPercentage > 0f;
+            return hitGroup.hitCount > 0f;
         }
     }
 }

--- a/Assets/Code/_Common/RayHitGroup.cs
+++ b/Assets/Code/_Common/RayHitGroup.cs
@@ -11,6 +11,13 @@ namespace PQ.Common
         public readonly int   hitCount;
         public readonly float hitPercentage;
         public readonly float hitDistance;
+        
+        public override string ToString() =>
+            $"{GetType().Name}:{{" +
+                $"rayCount:{rayCount}," +
+                $"hitCount:{hitCount}," +
+                $"hitPercentage:{hitPercentage}," +
+                $"hitDistance:{hitDistance}}}";
 
         // todo: move results _into_ this class, or at least a reference to it
         public RayHitGroup(ReadOnlySpan<RayHit> hits)
@@ -29,9 +36,10 @@ namespace PQ.Common
 
             this.rayCount      = rayCount;
             this.hitCount      = hitCount;
-            this.hitPercentage = distanceSum > 0f? ((float)rayCount / hitCount)    : 0f;
+            this.hitPercentage = hitCount    > 0f? ((float)rayCount / hitCount)    : 0f;
             this.hitDistance   = distanceSum > 0f? ((float)rayCount / distanceSum) : 0f;
         }
+
 
         public static implicit operator bool(RayHitGroup hitGroup)
         {

--- a/Assets/Code/_Common/RayHitGroup.cs
+++ b/Assets/Code/_Common/RayHitGroup.cs
@@ -18,7 +18,7 @@ namespace PQ.Common
 
         public static implicit operator bool(RayHitGroup hitGroup)
         {
-            return Mathf.Approximately(hitGroup.hitPercentage, 0f);
+            return hitGroup.hitPercentage > 0f;
         }
     }
 }


### PR DESCRIPTION
# Simplifying ray cast results
Makes debugging easier by:
* Simplifying the results
* Removing nullable ? operator and using implicit check instead
* Moving computations from segment to result struct
* Drawing debug ray all the way to max distance to make excessiveness obvious
* Rename field suffix in box caster to use caster instead of sensor for each segment caster