### PR TITLE
Game Event Improvements Part 2: Empty event args and payload data

### DIFF
--- a/Assets/Code/Entities/Character2D.cs
+++ b/Assets/Code/Entities/Character2D.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using UnityEngine;
+﻿using UnityEngine;
 using PQ.Common;
 using PQ.Common.Extensions;
 
@@ -13,6 +12,7 @@ namespace PQ.Entities
         private bool _isGrounded;
         private KinematicBody2D _body;
 
+        public bool IsGrounded => _isGrounded;
         public GameEvent<bool> GroundContactChanged = new("character2D.groundContact.change");
         public Character2DSettings Settings { get; set; }
 

--- a/Assets/Code/Entities/Penguin/Components/PenguinAnimation.cs
+++ b/Assets/Code/Entities/Penguin/Components/PenguinAnimation.cs
@@ -47,14 +47,14 @@ namespace PQ.Entities.Penguin
         // rather it's an animation related kept here for relevance
         public float LocomotionBlendStep => _locomotionBlendStep;
 
-        public GameEvent<string> JumpLiftOff     = new("animation.jump.liftoff");
-        public GameEvent<string> LieDownStarted  = new("animation.liedown.start");
-        public GameEvent<string> LieDownMidpoint = new("animation.liedown.mid");
-        public GameEvent<string> LieDownEnded    = new("animation.liedown.end");
-        public GameEvent<string> StandUpStarted  = new("animation.standUp.start");
-        public GameEvent<string> StandUpEnded    = new("animation.standup.end");
-        public GameEvent<string> Fired           = new("animation.fire");
-        public GameEvent<string> Used            = new("animation.use");
+        public GameEvent<IEventPayload.Empty> JumpLiftOff     = new("animation.jump.liftoff");
+        public GameEvent<IEventPayload.Empty> LieDownStarted  = new("animation.liedown.start");
+        public GameEvent<IEventPayload.Empty> LieDownMidpoint = new("animation.liedown.mid");
+        public GameEvent<IEventPayload.Empty> LieDownEnded    = new("animation.liedown.end");
+        public GameEvent<IEventPayload.Empty> StandUpStarted  = new("animation.standUp.start");
+        public GameEvent<IEventPayload.Empty> StandUpEnded    = new("animation.standup.end");
+        public GameEvent<IEventPayload.Empty> Fired           = new("animation.fire");
+        public GameEvent<IEventPayload.Empty> Used            = new("animation.use");
 
 
         public void ResetAllTriggers()
@@ -74,11 +74,11 @@ namespace PQ.Entities.Penguin
         public void SetParamSlopeIntensity(float ratio)      => _animator.SetFloat(paramSlope,      ratio);
         public void SetParamIsGrounded(bool value)           => _animator.SetBool(paramIsGrounded,  value);
         
-        public void TriggerParamLieDownParameter()        => _animator.SetTrigger(paramLie);
-        public void TriggerParamStandUpParameter()        => _animator.SetTrigger(paramStand);
-        public void TriggerParamJumpUpParameter()         => _animator.SetTrigger(paramJump);
-        public void TriggerParamFireParameter()           => _animator.SetTrigger(paramFire);
-        public void TriggerParamUseParameter()            => _animator.SetTrigger(paramUse);
+        public void TriggerParamLieDownParameter()           => _animator.SetTrigger(paramLie);
+        public void TriggerParamStandUpParameter()           => _animator.SetTrigger(paramStand);
+        public void TriggerParamJumpUpParameter()            => _animator.SetTrigger(paramJump);
+        public void TriggerParamFireParameter()              => _animator.SetTrigger(paramFire);
+        public void TriggerParamUseParameter()               => _animator.SetTrigger(paramUse);
         
         
         private void OnLieDownAnimationEventStart()  => ForwardAsEvent(OnLieDownAnimationEventStart,  LieDownStarted);
@@ -93,16 +93,14 @@ namespace PQ.Entities.Penguin
         private void OnUseAnimationEvent()           => ForwardAsEvent(OnUseAnimationEvent,           Used);
 
 
-        private void ForwardAsEvent(Action animatorEvent, GameEvent<string> customEvent)
+        private void ForwardAsEvent(Action animatorEvent, GameEvent<IEventPayload.Empty> customEvent)
         {
-            // todo: get rid of these dummy string parameters
-            // todo: look into moving event forwarding into GameEvent class
             if (_logEvents)
             {
                 Debug.Log($"[Frame:{Time.frameCount - 1}] " +
                           $"Received {animatorEvent.Method.Name}, forwarding as {customEvent.Name}");
             }
-            customEvent.Trigger(eventData: "");
+            customEvent.Trigger(payload: IEventPayload.Empty.Value);
         }
     }
 }

--- a/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
@@ -36,7 +36,7 @@ namespace PQ.Entities.Penguin
         }
 
 
-        private void OnLieDownAnimationStarted(string _)
+        private void OnLieDownAnimationStarted(IEventPayload.Empty _)
         {
             // disable our box and feet, to prevent catching on edges when changing posture from OnFeet to OnBelly
             _blob.ColliderConstraints =
@@ -44,7 +44,7 @@ namespace PQ.Entities.Penguin
                 PenguinColliderConstraints.DisableFeet;
         }
 
-        private void OnLieDownAnimationMidpoint(string _)
+        private void OnLieDownAnimationMidpoint(IEventPayload.Empty _)
         {
             // disable our box and feet, to prevent catching on edges when changing posture from OnFeet to OnBelly
             _blob.ColliderConstraints =
@@ -53,7 +53,7 @@ namespace PQ.Entities.Penguin
                 PenguinColliderConstraints.DisableFlippers;
         }
 
-        private void OnLieDownAnimationFinished(string _)
+        private void OnLieDownAnimationFinished(IEventPayload.Empty _)
         {
             // keep our feet and flippers disabled to avoid interference with ground while OnBelly,
             // but enable everything else including bounding box

--- a/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
@@ -21,22 +21,22 @@ namespace PQ.Entities.Penguin
 
         public override void OnEnter()
         {
-            _blob.Animation.LieDownStarted .AddListener(OnLieDownAnimationStarted);
-            _blob.Animation.LieDownMidpoint.AddListener(OnLieDownAnimationMidpoint);
-            _blob.Animation.LieDownEnded   .AddListener(OnLieDownAnimationFinished);
+            _blob.Animation.LieDownStarted .AddListener(HandleLieDownAnimationStarted);
+            _blob.Animation.LieDownMidpoint.AddListener(HandleLieDownAnimationMidpoint);
+            _blob.Animation.LieDownEnded   .AddListener(HandleLieDownAnimationFinished);
 
             _blob.Animation.TriggerParamLieDownParameter();
         }
 
         public override void OnExit()
         {
-            _blob.Animation.LieDownStarted .RemoveListener(OnLieDownAnimationStarted);
-            _blob.Animation.LieDownMidpoint.RemoveListener(OnLieDownAnimationMidpoint);
-            _blob.Animation.LieDownEnded   .RemoveListener(OnLieDownAnimationFinished);
+            _blob.Animation.LieDownStarted .RemoveListener(HandleLieDownAnimationStarted);
+            _blob.Animation.LieDownMidpoint.RemoveListener(HandleLieDownAnimationMidpoint);
+            _blob.Animation.LieDownEnded   .RemoveListener(HandleLieDownAnimationFinished);
         }
 
 
-        private void OnLieDownAnimationStarted(IEventPayload.Empty _)
+        private void HandleLieDownAnimationStarted(IEventPayload.Empty _)
         {
             // disable our box and feet, to prevent catching on edges when changing posture from OnFeet to OnBelly
             _blob.ColliderConstraints =
@@ -44,7 +44,7 @@ namespace PQ.Entities.Penguin
                 PenguinColliderConstraints.DisableFeet;
         }
 
-        private void OnLieDownAnimationMidpoint(IEventPayload.Empty _)
+        private void HandleLieDownAnimationMidpoint(IEventPayload.Empty _)
         {
             // disable our box and feet, to prevent catching on edges when changing posture from OnFeet to OnBelly
             _blob.ColliderConstraints =
@@ -53,7 +53,7 @@ namespace PQ.Entities.Penguin
                 PenguinColliderConstraints.DisableFlippers;
         }
 
-        private void OnLieDownAnimationFinished(IEventPayload.Empty _)
+        private void HandleLieDownAnimationFinished(IEventPayload.Empty _)
         {
             // keep our feet and flippers disabled to avoid interference with ground while OnBelly,
             // but enable everything else including bounding box

--- a/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
@@ -13,17 +13,13 @@ namespace PQ.Entities.Penguin
 
         public PenguinStateMidair(PenguinStateMachineDriver driver, string name,
             PenguinBlob blob, GameEventCenter eventCenter)
-            : base(name, MakeEvents())
+            : base(name, eventRegistry: null)
         {
             _blob = blob;
             _driver = driver;
             _eventCenter = eventCenter;
         }
 
-        private static GameEventRegistry MakeEvents()
-        {
-            return new GameEventRegistry();
-        }
 
         public override void OnEnter()
         {

--- a/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
@@ -27,21 +27,22 @@ namespace PQ.Entities.Penguin
 
         public override void OnEnter()
         {
-            _blob.CharacterController.GroundContactChanged.AddListener(OnGroundContactChanged);
+            _blob.CharacterController.GroundContactChanged.AddListener(HandleGroundContactChanged);
 
             _blob.Animation.TriggerParamJumpUpParameter();
         }
 
         public override void OnExit()
         {
-            _blob.CharacterController.GroundContactChanged.RemoveListener(OnGroundContactChanged);
+            _blob.CharacterController.GroundContactChanged.RemoveListener(HandleGroundContactChanged);
 
             // reset any triggers such that any pending animation events are cleared out to avoid them
             // from firing automatically on landing
             _blob.Animation.ResetAllTriggers();
         }
 
-        private void OnGroundContactChanged(bool isGrounded)
+
+        private void HandleGroundContactChanged(bool isGrounded)
         {
             _blob.Animation.SetParamIsGrounded(isGrounded);
             if (isGrounded)

--- a/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
@@ -20,9 +20,9 @@ namespace PQ.Entities.Penguin
             _eventCenter = eventCenter;
         }
 
-        private static GameEventRegistry<object> MakeEvents()
+        private static GameEventRegistry MakeEvents()
         {
-            return new GameEventRegistry<object>();
+            return new GameEventRegistry();
         }
 
         public override void OnEnter()

--- a/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
@@ -30,7 +30,7 @@ namespace PQ.Entities.Penguin
 
             _blob.CharacterController.Settings = _blob.OnBellySettings;
             _locomotionBlend = 0.0f;
-            _horizontalInput = HorizontalInput.None;
+            _horizontalInput = new(HorizontalInput.Type.None);
         }
 
         public override void OnExit()
@@ -51,17 +51,17 @@ namespace PQ.Entities.Penguin
 
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
         private void OnGroundContactChanged(bool isGrounded) => _blob.Animation.SetParamIsGrounded(isGrounded);
-        private void OnStandUpInputReceived(string _) => _driver.MoveToState(_driver.StateStandingUp);
+        private void OnStandUpInputReceived(IEventPayload.Empty _) => _driver.MoveToState(_driver.StateStandingUp);
 
         // todo: find a flexible solution for all this duplicated movement code in multiple states
         private void OnMoveHorizontalChanged(HorizontalInput state)
         {
             _horizontalInput = state;
-            if (_horizontalInput == HorizontalInput.Right)
+            if (_horizontalInput.value == HorizontalInput.Type.Right)
             {
                 _blob.CharacterController.FaceRight();
             }
-            else if (_horizontalInput == HorizontalInput.Left)
+            else if (_horizontalInput.value == HorizontalInput.Type.Left)
             {
                 _blob.CharacterController.FaceLeft();
             }
@@ -69,7 +69,7 @@ namespace PQ.Entities.Penguin
 
         private void HandleHorizontalMovement()
         {
-            if (_horizontalInput == HorizontalInput.None)
+            if (_horizontalInput.value == HorizontalInput.Type.None)
             {
                 _locomotionBlend = Mathf.Clamp01(_locomotionBlend - _blob.Animation.LocomotionBlendStep);
             }

--- a/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
@@ -24,9 +24,9 @@ namespace PQ.Entities.Penguin
 
         public override void OnEnter()
         {
-            _eventCenter.standUpCommand      .AddListener(OnStandUpInputReceived);
-            _eventCenter.movementInputChanged.AddListener(OnMoveHorizontalChanged);
-            _blob.CharacterController.GroundContactChanged.AddListener(OnGroundContactChanged);
+            _eventCenter.standUpCommand      .AddListener(HandleStandUpInputReceived);
+            _eventCenter.movementInputChanged.AddListener(HandleHorizontalChanged);
+            _blob.CharacterController.GroundContactChanged.AddListener(HandleGroundContactChanged);
 
             _blob.CharacterController.Settings = _blob.OnBellySettings;
             _locomotionBlend = 0.0f;
@@ -35,9 +35,9 @@ namespace PQ.Entities.Penguin
 
         public override void OnExit()
         {
-            _eventCenter.standUpCommand      .RemoveListener(OnStandUpInputReceived);
-            _eventCenter.movementInputChanged.RemoveListener(OnMoveHorizontalChanged);
-            _blob.CharacterController.GroundContactChanged.RemoveListener(OnGroundContactChanged);
+            _eventCenter.standUpCommand      .RemoveListener(HandleStandUpInputReceived);
+            _eventCenter.movementInputChanged.RemoveListener(HandleHorizontalChanged);
+            _blob.CharacterController.GroundContactChanged.RemoveListener(HandleGroundContactChanged);
 
             _locomotionBlend = 0.0f;
             _blob.Animation.SetParamLocomotionIntensity(_locomotionBlend);
@@ -50,11 +50,11 @@ namespace PQ.Entities.Penguin
 
 
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
-        private void OnGroundContactChanged(bool isGrounded) => _blob.Animation.SetParamIsGrounded(isGrounded);
-        private void OnStandUpInputReceived(IEventPayload.Empty _) => _driver.MoveToState(_driver.StateStandingUp);
+        private void HandleGroundContactChanged(bool isGrounded) => _blob.Animation.SetParamIsGrounded(isGrounded);
+        private void HandleStandUpInputReceived(IEventPayload.Empty _) => _driver.MoveToState(_driver.StateStandingUp);
 
         // todo: find a flexible solution for all this duplicated movement code in multiple states
-        private void OnMoveHorizontalChanged(HorizontalInput state)
+        private void HandleHorizontalChanged(HorizontalInput state)
         {
             _horizontalInput = state;
             if (_horizontalInput.value == HorizontalInput.Type.Right)

--- a/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
@@ -14,7 +14,8 @@ namespace PQ.Entities.Penguin
         private HorizontalInput _horizontalInput;
 
         public PenguinStateOnFeet(PenguinStateMachineDriver driver, string name,
-            PenguinBlob blob, GameEventCenter eventCenter) : base(name, eventRegistry: null)
+            PenguinBlob blob, GameEventCenter eventCenter)
+            : base(name, new GameEventRegistry())
         {
             _blob = blob;
             _driver = driver;

--- a/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
@@ -23,11 +23,11 @@ namespace PQ.Entities.Penguin
 
         public override void OnEnter()
         {
-            _blob.Animation.JumpLiftOff      .AddListener(OnJumpLiftOff);
-            _eventCenter.jumpCommand         .AddListener(OnJumpInputReceived);
-            _eventCenter.lieDownCommand      .AddListener(OnLieDownInputReceived);
-            _eventCenter.movementInputChanged.AddListener(OnMoveHorizontalChanged);
-            _blob.CharacterController.GroundContactChanged.AddListener(OnGroundContactChanged);
+            _blob.Animation.JumpLiftOff      .AddListener(HandleJumpLiftOff);
+            _eventCenter.jumpCommand         .AddListener(HandleJumpInputReceived);
+            _eventCenter.lieDownCommand      .AddListener(HandleLieDownInputReceived);
+            _eventCenter.movementInputChanged.AddListener(HandleMoveHorizontalChanged);
+            _blob.CharacterController.GroundContactChanged.AddListener(HandleGroundContactChanged);
 
             _blob.CharacterController.Settings = _blob.OnFeetSettings;
             _locomotionBlend = 0.0f;
@@ -36,11 +36,11 @@ namespace PQ.Entities.Penguin
 
         public override void OnExit()
         {
-            _blob.Animation.JumpLiftOff      .RemoveListener(OnJumpLiftOff);
-            _eventCenter.jumpCommand         .RemoveListener(OnJumpInputReceived);
-            _eventCenter.lieDownCommand      .RemoveListener(OnLieDownInputReceived);
-            _eventCenter.movementInputChanged.RemoveListener(OnMoveHorizontalChanged);
-            _blob.CharacterController.GroundContactChanged.RemoveListener(OnGroundContactChanged);
+            _blob.Animation.JumpLiftOff      .RemoveListener(HandleJumpLiftOff);
+            _eventCenter.jumpCommand         .RemoveListener(HandleJumpInputReceived);
+            _eventCenter.lieDownCommand      .RemoveListener(HandleLieDownInputReceived);
+            _eventCenter.movementInputChanged.RemoveListener(HandleMoveHorizontalChanged);
+            _blob.CharacterController.GroundContactChanged.RemoveListener(HandleGroundContactChanged);
 
             _locomotionBlend = 0.0f;
             _horizontalInput = new(HorizontalInput.Type.None);
@@ -52,13 +52,14 @@ namespace PQ.Entities.Penguin
             HandleHorizontalMovement();
         }
 
+
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
-        private void OnLieDownInputReceived(IEventPayload.Empty _)
+        private void HandleLieDownInputReceived(IEventPayload.Empty _)
         {
             _driver.MoveToState(_driver.StateLyingDown);
         }
 
-        private void OnGroundContactChanged(bool isGrounded)
+        private void HandleGroundContactChanged(bool isGrounded)
         {
             _blob.Animation.SetParamIsGrounded(isGrounded);
             if (!isGrounded)
@@ -68,19 +69,19 @@ namespace PQ.Entities.Penguin
         }
 
 
-        private void OnJumpInputReceived(IEventPayload.Empty _)
+        private void HandleJumpInputReceived(IEventPayload.Empty _)
         {
             _blob.Animation.TriggerParamJumpUpParameter();
         }
 
-        private void OnJumpLiftOff(IEventPayload.Empty _)
+        private void HandleJumpLiftOff(IEventPayload.Empty _)
         {
             _blob.CharacterController.Jump();
         }
 
 
         // todo: find a flexible solution for all this duplicated movement code in multiple states
-        private void OnMoveHorizontalChanged(HorizontalInput state)
+        private void HandleMoveHorizontalChanged(HorizontalInput state)
         {
             _horizontalInput = state;
             if (_horizontalInput.value == HorizontalInput.Type.Right)

--- a/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
@@ -31,7 +31,7 @@ namespace PQ.Entities.Penguin
 
             _blob.CharacterController.Settings = _blob.OnFeetSettings;
             _locomotionBlend = 0.0f;
-            _horizontalInput = HorizontalInput.None;
+            _horizontalInput = new(HorizontalInput.Type.None);
         }
 
         public override void OnExit()
@@ -43,7 +43,7 @@ namespace PQ.Entities.Penguin
             _blob.CharacterController.GroundContactChanged.RemoveListener(OnGroundContactChanged);
 
             _locomotionBlend = 0.0f;
-            _horizontalInput = HorizontalInput.None;
+            _horizontalInput = new(HorizontalInput.Type.None);
             _blob.Animation.SetParamLocomotionIntensity(_locomotionBlend);
         }
 
@@ -53,7 +53,7 @@ namespace PQ.Entities.Penguin
         }
 
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
-        private void OnLieDownInputReceived(string _)
+        private void OnLieDownInputReceived(IEventPayload.Empty _)
         {
             _driver.MoveToState(_driver.StateLyingDown);
         }
@@ -68,12 +68,12 @@ namespace PQ.Entities.Penguin
         }
 
 
-        private void OnJumpInputReceived(string _)
+        private void OnJumpInputReceived(IEventPayload.Empty _)
         {
             _blob.Animation.TriggerParamJumpUpParameter();
         }
 
-        private void OnJumpLiftOff(string _)
+        private void OnJumpLiftOff(IEventPayload.Empty _)
         {
             _blob.CharacterController.Jump();
         }
@@ -83,11 +83,11 @@ namespace PQ.Entities.Penguin
         private void OnMoveHorizontalChanged(HorizontalInput state)
         {
             _horizontalInput = state;
-            if (_horizontalInput == HorizontalInput.Right)
+            if (_horizontalInput.value == HorizontalInput.Type.Right)
             {
                 _blob.CharacterController.FaceRight();
             }
-            else if (_horizontalInput == HorizontalInput.Left)
+            else if (_horizontalInput.value == HorizontalInput.Type.Left)
             {
                 _blob.CharacterController.FaceLeft();
             }
@@ -95,7 +95,7 @@ namespace PQ.Entities.Penguin
 
         private void HandleHorizontalMovement()
         {
-            if (_horizontalInput == HorizontalInput.None)
+            if (_horizontalInput.value == HorizontalInput.Type.None)
             {
                 _locomotionBlend = Mathf.Clamp01(_locomotionBlend - _blob.Animation.LocomotionBlendStep);
             }

--- a/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
@@ -33,13 +33,13 @@ namespace PQ.Entities.Penguin
         }
 
 
-        private void OnStandUpAnimationStarted(string _)
+        private void OnStandUpAnimationStarted(IEventPayload.Empty _)
         {
             // keep all colliders on _except_ for the bounding box, to prevent catching on edges during posture change
             _blob.ColliderConstraints = PenguinColliderConstraints.DisableBoundingBox;
         }
 
-        private void OnStandUpAnimationFinished(string _)
+        private void OnStandUpAnimationFinished(IEventPayload.Empty _)
         {
             // enable all colliders as we are now fully onFeet
             _blob.ColliderConstraints = PenguinColliderConstraints.None;

--- a/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
@@ -20,26 +20,26 @@ namespace PQ.Entities.Penguin
 
         public override void OnEnter()
         {
-            _blob.Animation.StandUpStarted.AddListener(OnStandUpAnimationStarted);
-            _blob.Animation.StandUpEnded  .AddListener(OnStandUpAnimationFinished);
+            _blob.Animation.StandUpStarted.AddListener(HandleStandUpAnimationStarted);
+            _blob.Animation.StandUpEnded  .AddListener(HandleStandUpAnimationFinished);
 
             _blob.Animation.TriggerParamStandUpParameter();
         }
 
         public override void OnExit()
         {
-            _blob.Animation.StandUpStarted.RemoveListener(OnStandUpAnimationStarted);
-            _blob.Animation.StandUpEnded.RemoveListener(OnStandUpAnimationFinished);
+            _blob.Animation.StandUpStarted.RemoveListener(HandleStandUpAnimationStarted);
+            _blob.Animation.StandUpEnded.RemoveListener(HandleStandUpAnimationFinished);
         }
 
 
-        private void OnStandUpAnimationStarted(IEventPayload.Empty _)
+        private void HandleStandUpAnimationStarted(IEventPayload.Empty _)
         {
             // keep all colliders on _except_ for the bounding box, to prevent catching on edges during posture change
             _blob.ColliderConstraints = PenguinColliderConstraints.DisableBoundingBox;
         }
 
-        private void OnStandUpAnimationFinished(IEventPayload.Empty _)
+        private void HandleStandUpAnimationFinished(IEventPayload.Empty _)
         {
             // enable all colliders as we are now fully onFeet
             _blob.ColliderConstraints = PenguinColliderConstraints.None;

--- a/Assets/Code/GameController.cs
+++ b/Assets/Code/GameController.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using PQ.Common;
 
 
 namespace PQ
@@ -22,7 +23,7 @@ namespace PQ
         {
             _gameEventCenter = GameEventCenter.Instance;
             _playerPenguin.SetActive(true);
-            _gameEventCenter.startNewGame.AddOneShotListener(StartNewGame);
+            _gameEventCenter.startNewGame.AddListener(StartNewGame);
         }
 
         void OnEnable()
@@ -41,28 +42,11 @@ namespace PQ
             _gameEventCenter.scoreChange.Trigger(_playerInfo);
         }
 
-        private void RestartGame(string status)
+        private void RestartGame(IEventPayload.Empty _)
         {
             ResetMovingObjects();
             _playerInfo = new PlayerProgressionInfo(_playerInfo.Lives);
             _gameEventCenter.scoreChange.Trigger(_playerInfo);
-        }
-
-        private void UpdateScore(int points)
-        {
-            if (_playerInfo == null)
-            {
-                Debug.LogError($"RecordedScore that is set upon starting a new game {GetType().Name} is missing, " +
-                               $"perhaps the event wasn't fired or listened to? " +
-                               $"...If running from game scene in play mode, try starting from main menu instead");
-            }
-
-            _playerInfo.AddToScore(points);
-            _gameEventCenter.scoreChange.Trigger(_playerInfo);
-            if (LoseConditionMet() || WinConditionMet())
-            {
-                _gameEventCenter.gameOver.Trigger(_playerInfo);
-            }
         }
 
         // placeholders for gameover conditions (will be based on level progression, score etc in future)
@@ -70,6 +54,7 @@ namespace PQ
         {
             return false;
         }
+
         private bool WinConditionMet()
         {
             return false;

--- a/Assets/Code/GameEventCenter.cs
+++ b/Assets/Code/GameEventCenter.cs
@@ -3,12 +3,15 @@
 
 namespace PQ
 {
-    // todo: find a better spot for this
-    public enum HorizontalInput
+    // todo: find a better place for this
+    public struct HorizontalInput : IEventPayload
     {
-        None,
-        Left,
-        Right
+        public enum Type { None, Left, Right }
+        public readonly Type value;
+        public HorizontalInput(Type value)
+        {
+            this.value = value;
+        }
     }
 
     // todo: replace this with GameEventRegistries for UI, Commands, etc
@@ -20,21 +23,20 @@ namespace PQ
     */
     public class GameEventCenter
     {
-        public GameEvent<string>                jumpCommand          = new("command.jump");
         public GameEvent<HorizontalInput>       movementInputChanged = new("command.movement");
-        public GameEvent<string>                lieDownCommand       = new("command.lieDown");
-        public GameEvent<string>                standUpCommand       = new("command.standUp");
-        public GameEvent<string>                useCommand           = new("command.use");
-        public GameEvent<string>                fireCommand          = new("command.fire");
+        public GameEvent<IEventPayload.Empty>   jumpCommand          = new("command.jump");
+        public GameEvent<IEventPayload.Empty>   lieDownCommand       = new("command.lieDown");
+        public GameEvent<IEventPayload.Empty>   standUpCommand       = new("command.standUp");
+        public GameEvent<IEventPayload.Empty>   useCommand           = new("command.use");
+        public GameEvent<IEventPayload.Empty>   fireCommand          = new("command.fire");
 
         public GameEvent<PlayerProgressionInfo> scoreChange          = new("score.changed");
-        
         public GameEvent<PlayerSettingsInfo>    startNewGame         = new("game.new");
         public GameEvent<PlayerProgressionInfo> pauseGame            = new("game.pause");
-        public GameEvent<string>                resumeGame           = new("game.resume");
-        public GameEvent<string>                gotoMainMenu         = new("game.openMainMenu");
         public GameEvent<PlayerProgressionInfo> gameOver             = new("game.over");
-        public GameEvent<string>                restartGame          = new("game.restart");
+        public GameEvent<IEventPayload.Empty>   resumeGame           = new("game.resume");
+        public GameEvent<IEventPayload.Empty>   gotoMainMenu         = new("game.openMainMenu");
+        public GameEvent<IEventPayload.Empty>   restartGame          = new("game.restart");
 
         private static GameEventCenter _instance;
         public static GameEventCenter Instance

--- a/Assets/Code/PlayerGameplayInputReceiver.cs
+++ b/Assets/Code/PlayerGameplayInputReceiver.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.InputSystem;
 using PQ.Generated;
+using PQ.Common;
 
 
 namespace PQ
@@ -40,7 +41,7 @@ namespace PQ
             _use            = controls.Gameplay.Fire;
             _fire           = controls.Gameplay.Use;
 
-            _horizontalInputState = HorizontalInput.None;
+            _horizontalInputState = new(HorizontalInput.Type.None);
         }
 
 
@@ -70,51 +71,32 @@ namespace PQ
 
         private void OnMoveHorizontalChanged(InputAction.CallbackContext context)
         {
-            HorizontalInput mappedValue;
+            HorizontalInput.Type horizontalInputType;
             float rawValue = context.action.ReadValue<float>();
             if (Mathf.Approximately(rawValue, 0))
             {
-                mappedValue = HorizontalInput.None;
+                horizontalInputType = HorizontalInput.Type.None;
             }
             else if (rawValue < 0)
             {
-                mappedValue = HorizontalInput.Left;
+                horizontalInputType = HorizontalInput.Type.Left;
             }
             else
             {
-                mappedValue = HorizontalInput.Right;
+                horizontalInputType = HorizontalInput.Type.Right;
             }
 
-            if (mappedValue != _horizontalInputState)
+            if (_horizontalInputState.value != horizontalInputType)
             {
-                _eventCenter.movementInputChanged.Trigger(mappedValue);
-                _horizontalInputState = mappedValue;
+                _horizontalInputState = new(horizontalInputType);
+                _eventCenter.movementInputChanged.Trigger(_horizontalInputState);
             }
         }
 
-        private void OnJumpUp(InputAction.CallbackContext _)
-        {
-            _eventCenter.jumpCommand.Trigger("Received jump up input");
-        }
-
-        private void OnStandUp(InputAction.CallbackContext _)
-        {
-            _eventCenter.standUpCommand.Trigger("Received stand up input");
-        }
-
-        private void OnLieDown(InputAction.CallbackContext _)
-        {
-            _eventCenter.lieDownCommand.Trigger("Received lie down input");
-        }
-
-        private void OnUse(InputAction.CallbackContext _)
-        {
-            _eventCenter.useCommand.Trigger("Received use input");
-        }
-
-        private void OnFire(InputAction.CallbackContext _)
-        {
-            _eventCenter.fireCommand.Trigger("Received fire input");
-        }
+        private void OnJumpUp(InputAction.CallbackContext _)  => _eventCenter.jumpCommand   .Trigger(IEventPayload.Empty.Value);
+        private void OnStandUp(InputAction.CallbackContext _) => _eventCenter.standUpCommand.Trigger(IEventPayload.Empty.Value);
+        private void OnLieDown(InputAction.CallbackContext _) => _eventCenter.lieDownCommand.Trigger(IEventPayload.Empty.Value);
+        private void OnUse(InputAction.CallbackContext _)     => _eventCenter.useCommand    .Trigger(IEventPayload.Empty.Value);
+        private void OnFire(InputAction.CallbackContext _)    => _eventCenter.fireCommand   .Trigger(IEventPayload.Empty.Value);
     }
 }

--- a/Assets/Code/PlayerProgressionInfo.cs
+++ b/Assets/Code/PlayerProgressionInfo.cs
@@ -1,9 +1,10 @@
-﻿using UnityEngine;
+﻿using PQ.Common;
+using UnityEngine;
 
 
 namespace PQ
 {
-    public class PlayerProgressionInfo
+    public struct PlayerProgressionInfo : IEventPayload
     {
         public static int MIN_SCORE = 0;
         public static int MAX_SCORE = 10000;
@@ -24,17 +25,18 @@ namespace PQ
 
         public PlayerProgressionInfo(int livesGiven)
         {
-            Reset(livesGiven);
-        }
-
-        public void Reset(int livesGiven)
-        {
             LevelName = DEFAULT_LEVEL;
             if (ValidateBounds(livesGiven, MIN_LIVES_GIVEN, MAX_LIVES_GIVEN))
             {
                 Score = MIN_SCORE;
                 Lives = livesGiven;
                 LivesGiven = livesGiven;
+            }
+            else
+            {
+                Score      = default;
+                Lives      = default;
+                LivesGiven = default;
             }
         }
 

--- a/Assets/Code/PlayerSettingsInfo.cs
+++ b/Assets/Code/PlayerSettingsInfo.cs
@@ -1,10 +1,11 @@
 ﻿using UnityEngine;
 using System.Diagnostics.Contracts;
+using PQ.Common;
 
 
 namespace PQ
 {
-    public class PlayerSettingsInfo
+    public struct PlayerSettingsInfo : IEventPayload
     {
         public int   NumberOfLives   { get; private set; }
         public float DifficultyLevel { get; private set; }
@@ -27,10 +28,17 @@ namespace PQ
                 SoundVolume     = PercentToRatio(soundVolumePercent);
                 MusicVolume     = PercentToRatio(musicVolumePercent);
             }
+            else
+            {
+                NumberOfLives   = default;
+                DifficultyLevel = default;
+                SoundVolume     = default;
+                MusicVolume     = default;
+            }
         }
 
 
-        private bool ValidPositiveInteger(int value)
+        private static bool ValidPositiveInteger(int value)
         {
             if (value < 0)
             {
@@ -40,7 +48,7 @@ namespace PQ
             return true;
         }
 
-        private bool ValidatePercentage(int value)
+        private static bool ValidatePercentage(int value)
         {
             if (value < 0 || value > 100)
             {

--- a/Assets/Code/Sound/SoundEffectController.cs
+++ b/Assets/Code/Sound/SoundEffectController.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using PQ.Common;
 
 
 namespace PQ.Sound
@@ -52,7 +53,7 @@ namespace PQ.Sound
         {
             _audioSource.Pause();
         }
-        private void ResumeAnyActiveSoundEffects(string _)
+        private void ResumeAnyActiveSoundEffects(IEventPayload.Empty _)
         {
             _audioSource.UnPause();
         }

--- a/Assets/Code/Sound/SoundTrackController.cs
+++ b/Assets/Code/Sound/SoundTrackController.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using PQ.Common;
 
 
 namespace PQ.Sound
@@ -42,7 +43,7 @@ namespace PQ.Sound
             _track.volume = gameSettings.MusicVolume / 100.0f;
             _track.Play();
         }
-        private void RestartTrack(string _)
+        private void RestartTrack(IEventPayload.Empty _)
         {
             _track.Stop();
             _track.Play();
@@ -51,7 +52,7 @@ namespace PQ.Sound
         {
             _track.Pause();
         }
-        private void ResumeTrack(string _)
+        private void ResumeTrack(IEventPayload.Empty _)
         {
             _track.UnPause();
         }

--- a/Assets/Code/UI/IngameMenuController.cs
+++ b/Assets/Code/UI/IngameMenuController.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
+using PQ.Common;
 using PQ.Common.Extensions;
 
 
@@ -101,20 +102,20 @@ namespace PQ.UI
         private void ResumeGame()
         {
             ToggleMenuVisibility(false);
-            _eventCenter.resumeGame.Trigger("Resuming game");
+            _eventCenter.resumeGame.Trigger(IEventPayload.Empty.Value);
         }
 
         private void MoveToMainMenu()
         {
             Time.timeScale = 1;
-            _eventCenter.gotoMainMenu.Trigger("Opening main menu");
+            _eventCenter.gotoMainMenu.Trigger(IEventPayload.Empty.Value);
             SceneExtensions.LoadScene(_mainMenuSceneName);
         }
 
         private void TriggerRestartGameEvent()
         {
             ToggleMenuVisibility(false);
-            _eventCenter.restartGame.Trigger("Restarting game");
+            _eventCenter.restartGame.Trigger(IEventPayload.Empty.Value);
         }
     }
 }

--- a/Assets/Code/_Common/FsmState.cs
+++ b/Assets/Code/_Common/FsmState.cs
@@ -15,7 +15,7 @@ namespace PQ.Common
     {
         private readonly string _name;
         private bool _isActive;
-        private GameEventRegistry<object> _eventRegistry;
+        private GameEventRegistry _eventRegistry;
 
         public string Name     => _name;
         public bool   IsActive => _isActive;
@@ -32,7 +32,7 @@ namespace PQ.Common
         //
         // this determines what events should automatically be
         // registered/unregistered on event enter/exit on state construction
-        public FsmState(string name, in GameEventRegistry<object> eventRegistry)
+        public FsmState(string name, in GameEventRegistry eventRegistry)
         {
             _name          = name;
             _isActive      = false;

--- a/Assets/Code/_Common/GameEventRegistry.cs
+++ b/Assets/Code/_Common/GameEventRegistry.cs
@@ -5,18 +5,18 @@ using System.Text;
 
 namespace PQ.Common
 {
-    public class GameEventRegistry<EventData>
+    public class GameEventRegistry
     {
         private string _description;
-        private readonly Dictionary<GameEvent<EventData>, Action<EventData>> _eventToHandlerMapping;
+        
 
+        private readonly Dictionary<GameEvent<IEventPayload>, Action<IEventPayload>> _eventToHandlerMapping;
         public override string ToString() => _description;
 
-
-        public GameEventRegistry(params (GameEvent<EventData>, Action<EventData>)[] eventCallbacks)
+        public GameEventRegistry(params (GameEvent<IEventPayload>, Action<IEventPayload>)[] eventCallbacks)
         {
             var stringBuilder = new StringBuilder(eventCallbacks.Length);
-            _eventToHandlerMapping = new Dictionary<GameEvent<EventData>, Action<EventData>>(eventCallbacks.Length);
+            _eventToHandlerMapping = new(eventCallbacks.Length);
             foreach (var (event_, callback_) in eventCallbacks)
             {
                 _eventToHandlerMapping[event_] = callback_;

--- a/Assets/Scenes/Test_Minimal/RectEntity.cs
+++ b/Assets/Scenes/Test_Minimal/RectEntity.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using PQ.Common;
 using PQ.Entities;
 
 
@@ -17,7 +18,7 @@ namespace PQ.TestScenes.Minimal
         {
             _controller = gameObject.GetComponent<RectMovementController>();
             _eventCenter = GameEventCenter.Instance;
-            _horizontalInput = HorizontalInput.None;
+            _horizontalInput = new(HorizontalInput.Type.None);
 
             _controller.Settings = _characterSettings;
         }
@@ -36,7 +37,7 @@ namespace PQ.TestScenes.Minimal
 
         void Update()
         {
-            if (_horizontalInput != HorizontalInput.None)
+            if (_horizontalInput.value != HorizontalInput.Type.None)
             {
                 _controller.MoveForward();
             }
@@ -45,16 +46,16 @@ namespace PQ.TestScenes.Minimal
         private void OnMoveHorizontalChanged(HorizontalInput state)
         {
             _horizontalInput = state;
-            if (_horizontalInput == HorizontalInput.Right)
+            if (_horizontalInput.value == HorizontalInput.Type.Right)
             {
                 _controller.FaceRight();
             }
-            else if (_horizontalInput == HorizontalInput.Left)
+            else if (_horizontalInput.value == HorizontalInput.Type.Left)
             {
                 _controller.FaceLeft();
             }
         }
 
-        private void OnJump(string _) { }
+        private void OnJump(IEventPayload.Empty _) { }
     }
 }


### PR DESCRIPTION
# Empty event args and payload data
* Migrate all events over to payload style handlers
* Replace prefix 'On' with 'Handle' for all states' private method listeners to distinguish them from the overridable methods that also start with 'On'
* Clean up state initialization