### PR TITLE
Move state ownership into driver and graph, and use string keys for indirect access

### DIFF
--- a/Assets/Code/Entities/Penguin/PenguinBlob.cs
+++ b/Assets/Code/Entities/Penguin/PenguinBlob.cs
@@ -22,6 +22,13 @@ namespace PQ.Entities.Penguin
     [AddComponentMenu("PenguinBlob")]
     public class PenguinBlob : MonoBehaviour
     {
+        [Header("Penguin State Ids")]
+        public const string StateIdFeet       = "Penguin.State.OnFeet";
+        public const string StateIdBelly      = "Penguin.State.OnBelly";
+        public const string StateIdStandingUp = "Penguin.State.StandingUp";
+        public const string StateIdLyingDown  = "Penguin.State.LyingDown";
+        public const string StateIdMidair     = "Penguin.State.Midair";
+
         [Header("Body Part Collider Constraints")]
         [SerializeField] private PenguinColliderConstraints _colliderConstraints = PenguinColliderConstraints.DisableOuter;
         

--- a/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
+++ b/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
@@ -49,6 +49,7 @@ namespace PQ.Entities.Penguin
                     PenguinBlob.StateIdBelly
                 })
             );
+            SetInitialState(PenguinBlob.StateIdFeet);
         }
     }
 }

--- a/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
@@ -67,7 +67,7 @@ namespace PQ.Entities.Penguin
                 edgeRadius: 1.25f
             );
 
-            _driver.MoveToState(_driver.StateBelly);
+            _driver.MoveToState(PenguinBlob.StateIdBelly);
         }
     }
 }

--- a/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
@@ -49,7 +49,7 @@ namespace PQ.Entities.Penguin
 
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
         private void HandleGroundContactChanged(bool isGrounded) => _blob.Animation.SetParamIsGrounded(isGrounded);
-        private void HandleStandUpInputReceived() => _driver.MoveToState(_driver.StateStandingUp);
+        private void HandleStandUpInputReceived() => _driver.MoveToState(PenguinBlob.StateIdStandingUp);
 
         // todo: find a flexible solution for all this duplicated movement code in multiple states
         private void HandleMoveHorizontalChanged(HorizontalInput state)

--- a/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
@@ -54,7 +54,7 @@ namespace PQ.Entities.Penguin
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
         private void HandleLieDownInputReceived()
         {
-            _driver.MoveToState(_driver.StateLyingDown);
+            _driver.MoveToState(PenguinBlob.StateIdLyingDown);
         }
 
         private void HandleGroundContactChanged(bool isGrounded)
@@ -62,7 +62,7 @@ namespace PQ.Entities.Penguin
             _blob.Animation.SetParamIsGrounded(isGrounded);
             if (!isGrounded)
             {
-                _driver.MoveToState(_driver.StateMidair);
+                _driver.MoveToState(PenguinBlob.StateIdMidair);
             }
         }
 

--- a/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
@@ -54,7 +54,7 @@ namespace PQ.Entities.Penguin
                 edgeRadius: 0.68f
             );
 
-            _driver.MoveToState(_driver.StateFeet);
+            _driver.MoveToState(PenguinBlob.StateIdFeet);
 
             // todo: find a good way of having data for sliding and for onFeet that can be passed in here,
             //       and those values can be adjusted, perhaps in their own scriptable objects?

--- a/Assets/Code/_Common/Events/PqEventRegistry.cs
+++ b/Assets/Code/_Common/Events/PqEventRegistry.cs
@@ -66,14 +66,14 @@ namespace PQ.Common.Events
 
         private bool _active;
         private List<IEntry> _entries;
-        private FormattedList _formattedList;
+        private FormattedList<string> _formattedList;
 
 
         public PqEventRegistry()
         {
             _active = false;
             _entries = new();
-            _formattedList = new FormattedList();
+            _formattedList = new FormattedList<string>();
         }
 
         public bool IsActive => _active;

--- a/Assets/Code/_Common/States/FsmDriver.cs
+++ b/Assets/Code/_Common/States/FsmDriver.cs
@@ -23,32 +23,36 @@ namespace PQ.Common.States
 
         /*** External Facing Methods Used to Drive Transitions ***/
 
-        public FsmState InitialState => _initial;
-        public FsmState CurrentState => _current;
-        public FsmState LastState    => _last;
-        public FsmState NextState    => _next;
+        public string InitialState => _initial.Id;
+        public string CurrentState => _current.Id;
+        public string LastState    => _last.Id;
+        public string NextState    => _next.Id;
 
         public override string ToString() =>
             $"FsmDriver:{{" +
                 $"\nFsmHistory(" +
-                    $"initial:{InitialState.Name}," +
-                    $"current:{CurrentState.Name}," +
-                    $"last:{LastState.Name}," +
-                    $"next:{NextState.Name})" +
+                    $"initial:{InitialState}," +
+                    $"current:{CurrentState}," +
+                    $"last:{LastState}," +
+                    $"next:{NextState})" +
                 $"{_fsmGraph}" +
             $"}}";
 
 
         // Update our current state if transition was previously registered during initialization
-        public void MoveToState(FsmState next)
+        public void MoveToState(string stateId)
         {
             if (_next != null)
             {
-                throw new InvalidOperationException($"Cannot move to {next.Name} - a transition {_current.Name}=>{_next.Name} is already queued");
+                throw new InvalidOperationException($"Cannot move to {stateId} - a transition {_current.Id}=>{_next.Id} is already queued");
             }
-            if (!_fsmGraph.HasTransition(_current.Name, next.Name))
+            if (!_fsmGraph.TryGetState(stateId, out FsmState next))
             {
-                throw new InvalidOperationException($"Cannot move to {next.Name} - transition {_current.Name}=>{next.Name} was not found");
+                throw new InvalidOperationException($"Cannot move to {stateId} - state {next.Id} was not found");
+            }
+            if (!_fsmGraph.HasTransition(_current.Id, stateId))
+            {
+                throw new InvalidOperationException($"Cannot move to {stateId} - transition {_current.Id}=>{stateId} was not found");
             }
 
             _next = next;
@@ -59,31 +63,19 @@ namespace PQ.Common.States
         /*** Internal Hooks for Defining State Specific Logic ***/
 
         // Initialization method that MUST be called in OnInitialize in subclasses
-        protected void InitializeStates(params FsmState[] states)
-        {
-            _fsmGraph = new FsmGraph(states);
-
-            _initial = states[0];
-            for (int i = 0; i < states.Length; i++)
-            {
-                states[i].Initialize();
-            }
-
-            _initialized = true;
-        }
 
         // Mechanism for hooking up transitions use for validation when MoveToState is called by client
         // Can only be invoked in OnInitialize
-        protected void RegisterTransition(FsmState source, FsmState destination)
+        protected void InitializeGraph(params (FsmState, string[])[] states)
         {
-            _fsmGraph.AddTransition(source.Name, destination.Name);
+            _fsmGraph = new(states);
         }
 
         // Required callback for initializing
         protected abstract void OnInitialize();
 
         // Optional overridable callback for state transitions
-        protected virtual void OnTransition(FsmState previous, FsmState next) { }
+        protected virtual void OnTransition(string sourceId, string destinationId) { }
 
 
 
@@ -100,7 +92,7 @@ namespace PQ.Common.States
                     "InitializeStates must be called within subclass OnInitialize");
             }
 
-            _current = InitialState;
+            _current = _initial;
             _current.Enter();
         }
 
@@ -130,12 +122,12 @@ namespace PQ.Common.States
             }
 
             _current.Exit();
-            OnTransition(_current, _next);
+            OnTransition(_current.Id, _next.Id);
             _next.Enter();
 
-            _last = _current;
+            _last    = _current;
             _current = _next;
-            _next = null;
+            _next    = null;
             return true;
         }
     }

--- a/Assets/Code/_Common/States/FsmGraph.cs
+++ b/Assets/Code/_Common/States/FsmGraph.cs
@@ -6,9 +6,13 @@ using System.Collections.Generic;
 namespace PQ.Common.States
 {
     /*
-    Provides info about the state machine - the states, history.
+    Representation of the states and transitions in a finite state machine.
+
+    Note that it's effectively readonly - no new states or transitions after construction.
+
+    Also, states cannot have edges that loop directly back to itself.
     */
-    internal class FsmGraph
+    internal sealed class FsmGraph
     {
         private sealed class Node
         {

--- a/Assets/Code/_Common/States/FsmGraph.cs
+++ b/Assets/Code/_Common/States/FsmGraph.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Text;
 using System.Collections.Generic;
-using PQ.Common.Text;
 
 
 namespace PQ.Common.States
@@ -8,101 +8,98 @@ namespace PQ.Common.States
     /*
     Provides info about the state machine - the states, history.
     */
-    public class FsmGraph
+    internal class FsmGraph
     {
-        private bool _isDirty;
-        private string _description;
-        private readonly FsmState[] _states;
-        private Dictionary<string, HashSet<string>> _adjacencies;
-
-        public FsmGraph(params FsmState[] states)
+        private sealed class Node
         {
-            int stateCount = states.Length;
-            if (stateCount == 0)
+            public readonly FsmState state;
+            public readonly HashSet<string> neighbors;
+
+            public Node(FsmState state, HashSet<string> neighbors)
+            {
+                this.state = state;
+                this.neighbors = neighbors;
+            }
+        }
+
+        private readonly int _nodeCount;
+        private readonly int _edgeCount;
+        private readonly string _description;
+        private readonly Dictionary<string, Node> _nodes;
+        
+        public override string ToString() => _description;
+
+        /* Fill the graph with states, initialize them, and add their neighbors. */
+        public FsmGraph(params (FsmState, string[])[] states)
+        {
+            if (states == null || states.Length == 0)
             {
                 throw new ArgumentException("Fsm must have at least one state - received none");
             }
 
-            _isDirty = true;
-            _description = string.Empty;
-            _states = new FsmState[states.Length];
-            _adjacencies = new Dictionary<string, HashSet<string>>(stateCount);
-            for (int i = 0; i < stateCount; i++)
+            // fill in the state ids first, so we can use for validating the rest of the input
+            // when populating the graph states and transitions
+            _nodes = new Dictionary<string, Node>(states.Length);
+            foreach ((FsmState state, string[] _) in states)
             {
-                FsmState state = states[i];
-                if (state == null || string.IsNullOrEmpty(state.Name))
+                string stateId = state?.Id;
+                if (string.IsNullOrEmpty(stateId) || _nodes.ContainsKey(stateId))
                 {
-                    throw new ArgumentNullException($"Cannot add null or empty named state to graph");
+                    throw new ArgumentException($"Cannot add {stateId} state to graph - expected non null unique key");
                 }
-                if (_adjacencies.ContainsKey(state.Name))
+                _nodes.Add(key: stateId, value: null);
+            }
+            
+            _nodeCount = 0;
+            _edgeCount = 0;
+            StringBuilder nodesInfo = new($" states");
+            StringBuilder edgesInfo = new($" transitions");
+            foreach ((FsmState state, string[] destinations) in states)
+            {
+                string source = state.Id;
+                HashSet<string> neighbors = new(destinations.Length);
+                foreach (string dest in destinations)
                 {
-                    throw new ArgumentException($"Cannot add {state.Name} state to graph - already exists");
+                    if (source == dest || neighbors.Contains(dest) || !_nodes.ContainsKey(dest))
+                    {
+                        throw new ArgumentException($"Cannot add transition {source}=>{dest} to graph - expected unique existing key");
+                    }
+                    neighbors.Add(dest);
                 }
 
-                _states[i] = state;
-                _adjacencies[state.Name] = new HashSet<string>(stateCount);
+                state.Initialize();
+                nodesInfo.Append($"   ").AppendLine(state.ToString());
+                edgesInfo.Append($"   {source} => {{").AppendJoin(",", neighbors).Append($"}}").AppendLine();
+
+                _nodeCount++;
+                _edgeCount += neighbors.Count;
+                _nodes[source] = new(state, neighbors);
             }
+
+            _description = $"FsmGraph({_nodeCount} states, {_edgeCount} transitions) \n{nodesInfo} \n{edgesInfo}";
         }
 
-        public FsmState LookupState(string name)
+        public bool TryGetState(string id, out FsmState state)
         {
-            // todo: replace with more efficient lookup
-            return Array.Find(_states, state => state.Name == name);
+            if (!_nodes.ContainsKey(id))
+            {
+                state = null;
+                return false;
+            }
+
+            state = _nodes[id].state;
+            return true;
+        }
+
+        public bool HasState(string id)
+        {
+            return _nodes.ContainsKey(id);
         }
 
         public bool HasTransition(string source, string destination)
         {
-            return _adjacencies.ContainsKey(source) &&
-                   _adjacencies[source].Contains(destination);
-        }
-
-        public void AddTransition(string source, string destination)
-        {
-            if (!_adjacencies.ContainsKey(source) || !_adjacencies.ContainsKey(destination))
-            {
-                throw new ArgumentException($"Cannot add transition {source}=>{destination} to graph - both states must exist");
-            }
-            if (source == destination)
-            {
-                throw new ArgumentException($"Cannot add transition {source}=>{destination} to graph - cannot loop to state");
-            }
-            if (_adjacencies[source].Contains(destination))
-            {
-                throw new ArgumentException($"Cannot add transition {source}=>{destination} to graph - already exists");
-            }
-
-            _adjacencies[source].Add(destination);
-        }
-
-
-        private const string Indent1 = "\n  ";
-        private const string Indent2 = "\n    ";
-
-        public override string ToString()
-        {
-            if (!_isDirty)
-            {
-                return _description;
-            }
-
-            FormattedList statesList      = new(start: $"{Indent1}states:",      end: "\n", sep: Indent2);
-            FormattedList transitionsList = new(start: $"{Indent1}transitions:", end: "\n", sep: Indent2);
-            for (int stateIndex = 0; stateIndex < _states.Length; stateIndex++)
-            {
-                FsmState state = _states[stateIndex];
-                FormattedList stateTransitions = new($"{state.Name}:[", "]", ",", _adjacencies[state.Name]);
-
-                statesList.Append(state.ToString());
-                transitionsList.Append(stateTransitions.ToString());
-            }
-
-            _isDirty = false;
-            _description =
-                $"FsmGraph(" +
-                    $"{statesList}" +
-                    $"{transitionsList}" +
-                $")";
-            return _description;
+            return _nodes.ContainsKey(source) &&
+                   _nodes[source].neighbors.Contains(destination);
         }
     }
 }

--- a/Assets/Code/_Common/States/FsmState.cs
+++ b/Assets/Code/_Common/States/FsmState.cs
@@ -19,18 +19,21 @@ namespace PQ.Common.States
     */
     public abstract class FsmState : IEquatable<FsmState>, IComparable<FsmState>
     {
-        private readonly string _name;
+        private readonly string _id;
         private bool _active;
         private bool _initialized;
         private PqEventRegistry _eventRegistry;
 
-        public string Name => _name;
+        private PqEvent<string>           _moveToLastStateRequest = new("fsm.state.move.last");
+        private PqEvent<(string, string)> _moveToNextStateRequest = new("fsm.state.move.next");
+
+        public string Id;
         public bool IsActive => _active;
         public bool IsInitialized => _initialized;
 
         public override string ToString() =>
             $"FsmState(" +
-                $"name:{_name}," +
+                $"id:{_id}," +
                 $"eventRegistry:{_eventRegistry}" +
             $")";
 
@@ -40,13 +43,16 @@ namespace PQ.Common.States
 
         // External entry point for initializing the state
         // Note that any sub class dependencies should be hooked up via an override of this base constructor
-        public FsmState(string name)
+        public FsmState(string id)
         {
-            _name = name;
+            Id = id;
             _active = false;
-            _eventRegistry = new();
             _initialized = false;
+            _eventRegistry = new();
         }
+
+        public void OnMoveToLastStateSignaled(Action<string> onTrigger)           => _moveToLastStateRequest.AddHandler(onTrigger);
+        public void OnMoveToNextStateSignaled(Action<(string, string)> onTrigger) => _moveToNextStateRequest.AddHandler(onTrigger);
 
         // Entry point for client code initializing state instances
         // Any 'startup' code such as hooking up handlers to events is done here
@@ -83,10 +89,10 @@ namespace PQ.Common.States
         public void LateUpdate()  => OnLateUpdate();
 
 
-        int IComparable<FsmState>.CompareTo(FsmState other) => Name.CompareTo(other.Name);
-        bool IEquatable<FsmState>.Equals(FsmState other) => other is not null && Name == other.Name;
+        int IComparable<FsmState>.CompareTo(FsmState other) => Id.CompareTo(other.Id);
+        bool IEquatable<FsmState>.Equals(FsmState other) => other is not null && Id == other.Id;
         public override bool Equals(object obj) => ((IEquatable<FsmState>)this).Equals(obj as FsmState);
-        public override int GetHashCode() => HashCode.Combine(Name);
+        public override int GetHashCode() => HashCode.Combine(Id);
         public static bool operator ==(FsmState left, FsmState right) =>  Equals(left, right);
         public static bool operator !=(FsmState left, FsmState right) => !Equals(left, right);
 
@@ -97,6 +103,8 @@ namespace PQ.Common.States
         // Mechanism for hooking up events to handlers such that they can automatically be subscribed on state enter
         // and unsubscribed on state exit.
         // Can only be invoked in OnInitialize.
+        protected void SignalMoveToLastState() => _moveToLastStateRequest.Raise(_id);
+        protected void SignalMoveToNextState(string destinationStateId) => _moveToNextStateRequest.Raise((_id, destinationStateId));
         protected void RegisterEvent(IPqEventReceiver event_, Action handler_)          => _eventRegistry.Add(event_, handler_);
         protected void RegisterEvent<T>(IPqEventReceiver<T> event_, Action<T> handler_) => _eventRegistry.Add(event_, handler_);
 

--- a/Assets/Code/_Common/States/FsmState.cs
+++ b/Assets/Code/_Common/States/FsmState.cs
@@ -17,7 +17,7 @@ namespace PQ.Common.States
     of the module that handles the correct ordering of states. If it was done here, there would be tons
     of unnecessary and slow validation littered throughout the template hooks (eg Enter()).
     */
-    public abstract class FsmState : IEquatable<FsmState>
+    public abstract class FsmState : IEquatable<FsmState>, IComparable<FsmState>
     {
         private readonly string _name;
         private bool _active;
@@ -82,9 +82,10 @@ namespace PQ.Common.States
         // Execute logic intended for later on in a frame such as programmatic visual effects
         public void LateUpdate()  => OnLateUpdate();
 
-        
-        public bool Equals(FsmState other) => other is not null && Name == other.Name;
-        public override bool Equals(object obj) => Equals(obj as FsmState);
+
+        int IComparable<FsmState>.CompareTo(FsmState other) => Name.CompareTo(other.Name);
+        bool IEquatable<FsmState>.Equals(FsmState other) => other is not null && Name == other.Name;
+        public override bool Equals(object obj) => ((IEquatable<FsmState>)this).Equals(obj as FsmState);
         public override int GetHashCode() => HashCode.Combine(Name);
         public static bool operator ==(FsmState left, FsmState right) =>  Equals(left, right);
         public static bool operator !=(FsmState left, FsmState right) => !Equals(left, right);

--- a/Assets/Code/_Common/Text/FormattedList.cs
+++ b/Assets/Code/_Common/Text/FormattedList.cs
@@ -11,7 +11,7 @@ namespace PQ.Common.Text
     a streamlined way to create append-only formatted lists - which is a very common use case for logging
     in this game.
     */
-    public sealed class FormattedList
+    public sealed class FormattedList<T>
     {
         private readonly string _start;
         private readonly string _end;
@@ -23,7 +23,7 @@ namespace PQ.Common.Text
         public const string DefaultStart     = "[";
         public const string DefaultEnd       = "]";
         public const string DefaultSeperator = ",";
-        public static readonly string[] EmptyItems = System.Array.Empty<string>();
+        public static readonly T[] EmptyItems = System.Array.Empty<T>();
 
         public string Format => _start;
         public string Seperator => _seperator;
@@ -36,7 +36,7 @@ namespace PQ.Common.Text
         public FormattedList(string start, string end, string sep) :
             this(start, end, sep, EmptyItems) { }
 
-        public FormattedList(string start, string end, string sep, in IEnumerable<string> items)
+        public FormattedList(string start, string end, string sep, in IEnumerable<T> items)
         {
             string empty = start + end;
             _start     = start;
@@ -44,24 +44,32 @@ namespace PQ.Common.Text
             _seperator = sep;
             _text      = empty;
             _builder   = new StringBuilder(empty);
-            foreach (string item in items)
-            {
-                Append(item);
-            }
+
+            AppendAll(items);
+        }
+        
+        public void Reset()
+        {
+            _builder.Clear();
+            _builder.Append(_start);
+            _builder.Append(_end);
         }
 
-        public void Append(string item)
+        public void Append(T item)
         {
-            if (string.IsNullOrEmpty(item))
-            {
-                return;
-            }
-
             _builder.Remove(_text.Length - _end.Length, _end.Length);
             _builder.Append(_seperator);
             _builder.Append(item);
             _builder.Append(_end);
             _text = _builder.ToString();
+        }
+
+        public void AppendAll(in IEnumerable<T> items)
+        {
+            foreach (T item in items)
+            {
+                Append(item);
+            }
         }
     }
 }


### PR DESCRIPTION
# Move state ownership into driver and graph, and use string keys for indirect access
Part of making things more validated, explicit, and less error prone, this PR pulls the states (mostly, though have some follow up PRs for this) into the driver/graph, and sets up all the states and transitions all at once.