### PR TITLE
Make fsm setup simpler and more robust

### DIFF
--- a/Assets/Code/Entities/GenericBlob.cs
+++ b/Assets/Code/Entities/GenericBlob.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+
+namespace PQ.Entities
+{
+    /*
+    Generic blob of components.
+    */
+    [ExecuteAlways]
+    [System.Serializable]
+    public abstract class GenericBlob : MonoBehaviour
+    {
+
+    }
+}

--- a/Assets/Code/Entities/GenericBlob.cs.meta
+++ b/Assets/Code/Entities/GenericBlob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0db8043f15d83da4f953a06ac92daebe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/Entities/Penguin/PenguinBlob.cs
+++ b/Assets/Code/Entities/Penguin/PenguinBlob.cs
@@ -107,10 +107,13 @@ namespace PQ.Entities.Penguin
         void Start()
         {
             _colliderConstraints = GetConstraintsAccordingToDisabledColliders();
-            if (EventBus == null)
+            
+            #if UNITY_EDITOR
+            if (UnityEditor.EditorApplication.isPlaying && EventBus == null)
             {
                 throw new NullReferenceException("Caution: Event bus of penguin blob is disconnected");
             }
+            #endif
         }
 
         void Update()

--- a/Assets/Code/Entities/Penguin/PenguinBlob.cs
+++ b/Assets/Code/Entities/Penguin/PenguinBlob.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.Contracts;
 using UnityEngine;
 
@@ -20,14 +21,18 @@ namespace PQ.Entities.Penguin
     [ExecuteAlways]
     [System.Serializable]
     [AddComponentMenu("PenguinBlob")]
-    public class PenguinBlob : MonoBehaviour
+    public class PenguinBlob : GenericBlob
     {
+        // todo: think of a better way of doing this hooking up..
+        public GameEventCenter EventBus { get; set; }
+
         [Header("Penguin State Ids")]
         public const string StateIdFeet       = "Penguin.State.OnFeet";
         public const string StateIdBelly      = "Penguin.State.OnBelly";
         public const string StateIdStandingUp = "Penguin.State.StandingUp";
         public const string StateIdLyingDown  = "Penguin.State.LyingDown";
         public const string StateIdMidair     = "Penguin.State.Midair";
+
 
         [Header("Body Part Collider Constraints")]
         [SerializeField] private PenguinColliderConstraints _colliderConstraints = PenguinColliderConstraints.DisableOuter;
@@ -102,6 +107,10 @@ namespace PQ.Entities.Penguin
         void Start()
         {
             _colliderConstraints = GetConstraintsAccordingToDisabledColliders();
+            if (EventBus == null)
+            {
+                throw new NullReferenceException("Caution: Event bus of penguin blob is disconnected");
+            }
         }
 
         void Update()

--- a/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
+++ b/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
@@ -4,7 +4,6 @@ using PQ.Common.Fsm;
 
 namespace PQ.Entities.Penguin
 {
-
     public class PenguinFsmDriver : FsmDriver
     {
         private PenguinBlob _penguinBlob;
@@ -24,25 +23,26 @@ namespace PQ.Entities.Penguin
         protected override void OnInitialize()
         {
             _penguinBlob = gameObject.GetComponent<PenguinBlob>();
+
             _initialSpawnPosition = _penguinBlob.SkeletalRootPosition;
             ResetPositioning();
 
             InitializeGraph(
-                (new PenguinStateOnFeet(PenguinBlob.StateIdFeet, this, _penguinBlob), new[] {
+                (new PenguinStateOnFeet(PenguinBlob.StateIdFeet, _penguinBlob), new[] {
                     PenguinBlob.StateIdLyingDown,
                     PenguinBlob.StateIdMidair
                 }),
-                (new PenguinStateOnBelly(PenguinBlob.StateIdBelly, this, _penguinBlob), new[] {
+                (new PenguinStateOnBelly(PenguinBlob.StateIdBelly, _penguinBlob), new[] {
                     PenguinBlob.StateIdStandingUp,
                     PenguinBlob.StateIdMidair
                 }),
-                (new PenguinStateStandingUp(PenguinBlob.StateIdStandingUp, this, _penguinBlob), new[] {
+                (new PenguinStateStandingUp(PenguinBlob.StateIdStandingUp, _penguinBlob), new[] {
                     PenguinBlob.StateIdFeet,
                 }),
-                (new PenguinStateLyingDown(PenguinBlob.StateIdLyingDown, this, _penguinBlob), new[] {
+                (new PenguinStateLyingDown(PenguinBlob.StateIdLyingDown, _penguinBlob), new[] {
                     PenguinBlob.StateIdBelly
                 }),
-                (new PenguinStateMidair(PenguinBlob.StateIdMidair, this, _penguinBlob), new[] {
+                (new PenguinStateMidair(PenguinBlob.StateIdMidair, _penguinBlob), new[] {
                     PenguinBlob.StateIdFeet,
                     PenguinBlob.StateIdBelly
                 })

--- a/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
+++ b/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
@@ -7,7 +7,6 @@ namespace PQ.Entities.Penguin
 
     public class PenguinFsmDriver : FsmDriver
     {
-        private GameEventCenter _eventCenter;
         private PenguinBlob _penguinBlob;
         private Vector2 _initialSpawnPosition;
 
@@ -24,27 +23,26 @@ namespace PQ.Entities.Penguin
 
         protected override void OnInitialize()
         {
-            _eventCenter = GameEventCenter.Instance;
             _penguinBlob = gameObject.GetComponent<PenguinBlob>();
             _initialSpawnPosition = _penguinBlob.SkeletalRootPosition;
             ResetPositioning();
 
             InitializeGraph(
-                (new PenguinStateOnFeet(PenguinBlob.StateIdFeet, this, _penguinBlob, _eventCenter), new[] {
+                (new PenguinStateOnFeet(PenguinBlob.StateIdFeet, this, _penguinBlob), new[] {
                     PenguinBlob.StateIdLyingDown,
                     PenguinBlob.StateIdMidair
                 }),
-                (new PenguinStateOnBelly(PenguinBlob.StateIdBelly, this, _penguinBlob, _eventCenter), new[] {
+                (new PenguinStateOnBelly(PenguinBlob.StateIdBelly, this, _penguinBlob), new[] {
                     PenguinBlob.StateIdStandingUp,
                     PenguinBlob.StateIdMidair
                 }),
-                (new PenguinStateStandingUp(PenguinBlob.StateIdStandingUp, this, _penguinBlob, _eventCenter), new[] {
+                (new PenguinStateStandingUp(PenguinBlob.StateIdStandingUp, this, _penguinBlob), new[] {
                     PenguinBlob.StateIdFeet,
                 }),
-                (new PenguinStateLyingDown(PenguinBlob.StateIdLyingDown, this, _penguinBlob, _eventCenter), new[] {
+                (new PenguinStateLyingDown(PenguinBlob.StateIdLyingDown, this, _penguinBlob), new[] {
                     PenguinBlob.StateIdBelly
                 }),
-                (new PenguinStateMidair(PenguinBlob.StateIdMidair, this, _penguinBlob, _eventCenter), new[] {
+                (new PenguinStateMidair(PenguinBlob.StateIdMidair, this, _penguinBlob), new[] {
                     PenguinBlob.StateIdFeet,
                     PenguinBlob.StateIdBelly
                 })

--- a/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
+++ b/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
@@ -14,9 +14,9 @@ namespace PQ.Entities.Penguin
             _penguinBlob.CharacterController.PlaceAt(_initialSpawnPosition, rotation: 0);
         }
 
-        protected override void OnTransition(string sourceId, string destinationId)
+        protected override void OnTransition(string source, string dest)
         {
-            Debug.Log($"Transitioning Penguin from {sourceId} to {destinationId}");
+            Debug.Log($"Transitioning Penguin from {source} to {dest}");
         }
 
 

--- a/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
@@ -8,14 +8,11 @@ namespace PQ.Entities.Penguin
     {
         private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
-        private GameEventCenter _eventCenter;
 
-        public PenguinStateLyingDown(string name, PenguinFsmDriver driver,
-            PenguinBlob blob, GameEventCenter eventCenter) : base(name)
+        public PenguinStateLyingDown(string name, PenguinFsmDriver driver, PenguinBlob blob) : base(name)
         {
             _blob = blob;
             _driver = driver;
-            _eventCenter = eventCenter;
         }
 
         protected override void OnIntialize()

--- a/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateLyingDown.cs
@@ -6,13 +6,11 @@ namespace PQ.Entities.Penguin
 {
     public class PenguinStateLyingDown : FsmState
     {
-        private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
 
-        public PenguinStateLyingDown(string name, PenguinFsmDriver driver, PenguinBlob blob) : base(name)
+        public PenguinStateLyingDown(string name, PenguinBlob blob) : base(name)
         {
             _blob = blob;
-            _driver = driver;
         }
 
         protected override void OnIntialize()
@@ -64,7 +62,7 @@ namespace PQ.Entities.Penguin
                 edgeRadius: 1.25f
             );
 
-            _driver.MoveToState(PenguinBlob.StateIdBelly);
+            base.SignalMoveToNextState(PenguinBlob.StateIdBelly);
         }
     }
 }

--- a/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
@@ -9,14 +9,11 @@ namespace PQ.Entities.Penguin
     {
         private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
-        private GameEventCenter _eventCenter;
 
-        public PenguinStateMidair(string name, PenguinFsmDriver driver,
-            PenguinBlob blob, GameEventCenter eventCenter) : base(name)
+        public PenguinStateMidair(string name, PenguinFsmDriver driver, PenguinBlob blob) : base(name)
         {
             _blob = blob;
             _driver = driver;
-            _eventCenter = eventCenter;
         }
 
         protected override void OnIntialize()

--- a/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateMidair.cs
@@ -7,13 +7,11 @@ namespace PQ.Entities.Penguin
     // todo: add some sort of free fall check that forces a respawn/death
     public class PenguinStateMidair : FsmState
     {
-        private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
 
-        public PenguinStateMidair(string name, PenguinFsmDriver driver, PenguinBlob blob) : base(name)
+        public PenguinStateMidair(string name, PenguinBlob blob) : base(name)
         {
             _blob = blob;
-            _driver = driver;
         }
 
         protected override void OnIntialize()
@@ -39,7 +37,7 @@ namespace PQ.Entities.Penguin
             _blob.Animation.SetParamIsGrounded(isGrounded);
             if (isGrounded)
             {
-                _driver.MoveToState(_driver.LastState);
+                base.SignalMoveToLastState();
             }
         }
     }

--- a/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
@@ -8,23 +8,20 @@ namespace PQ.Entities.Penguin
     {
         private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
-        private GameEventCenter _eventCenter;
 
         private float _locomotionBlend;
         private HorizontalInput _horizontalInput;
 
-        public PenguinStateOnBelly(string name, PenguinFsmDriver driver,
-            PenguinBlob blob, GameEventCenter eventCenter) : base(name)
+        public PenguinStateOnBelly(string name, PenguinFsmDriver driver, PenguinBlob blob) : base(name)
         {
             _blob = blob;
             _driver = driver;
-            _eventCenter = eventCenter;
         }
 
         protected override void OnIntialize()
         {
-            RegisterEvent(_eventCenter.standUpCommand,                      HandleStandUpInputReceived);
-            RegisterEvent(_eventCenter.movementInputChange,                 HandleMoveHorizontalChanged);
+            RegisterEvent(_blob.EventBus.standUpCommand,                    HandleStandUpInputReceived);
+            RegisterEvent(_blob.EventBus.movementInputChange,               HandleMoveHorizontalChanged);
             RegisterEvent(_blob.CharacterController.OnGroundContactChanged, HandleGroundContactChanged);
         }
 

--- a/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnBelly.cs
@@ -6,16 +6,14 @@ namespace PQ.Entities.Penguin
 {
     public class PenguinStateOnBelly : FsmState
     {
-        private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
 
         private float _locomotionBlend;
         private HorizontalInput _horizontalInput;
 
-        public PenguinStateOnBelly(string name, PenguinFsmDriver driver, PenguinBlob blob) : base(name)
+        public PenguinStateOnBelly(string name, PenguinBlob blob) : base(name)
         {
             _blob = blob;
-            _driver = driver;
         }
 
         protected override void OnIntialize()
@@ -46,7 +44,7 @@ namespace PQ.Entities.Penguin
 
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
         private void HandleGroundContactChanged(bool isGrounded) => _blob.Animation.SetParamIsGrounded(isGrounded);
-        private void HandleStandUpInputReceived() => _driver.MoveToState(PenguinBlob.StateIdStandingUp);
+        private void HandleStandUpInputReceived() => base.SignalMoveToNextState(PenguinBlob.StateIdStandingUp);
 
         // todo: find a flexible solution for all this duplicated movement code in multiple states
         private void HandleMoveHorizontalChanged(HorizontalInput state)

--- a/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
@@ -8,26 +8,23 @@ namespace PQ.Entities.Penguin
     {
         private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
-        private GameEventCenter _eventCenter;
 
         private float _locomotionBlend;
         private HorizontalInput _horizontalInput;
 
-        public PenguinStateOnFeet(string name, PenguinFsmDriver driver,
-            PenguinBlob blob, GameEventCenter eventCenter)
+        public PenguinStateOnFeet(string name, PenguinFsmDriver driver, PenguinBlob blob)
             : base(name)
         {
             _blob = blob;
             _driver = driver;
-            _eventCenter = eventCenter;
         }
 
         protected override void OnIntialize()
         {
             RegisterEvent(_blob.Animation.JumpLiftOff,                      HandleJumpLiftOff);
-            RegisterEvent(_eventCenter.jumpCommand,                         HandleJumpInputReceived);
-            RegisterEvent(_eventCenter.lieDownCommand,                      HandleLieDownInputReceived);
-            RegisterEvent(_eventCenter.movementInputChange,                 HandleMoveHorizontalChanged);
+            RegisterEvent(_blob.EventBus.jumpCommand,                       HandleJumpInputReceived);
+            RegisterEvent(_blob.EventBus.lieDownCommand,                    HandleLieDownInputReceived);
+            RegisterEvent(_blob.EventBus.movementInputChange,               HandleMoveHorizontalChanged);
             RegisterEvent(_blob.CharacterController.OnGroundContactChanged, HandleGroundContactChanged);
         }
 

--- a/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateOnFeet.cs
@@ -6,17 +6,14 @@ namespace PQ.Entities.Penguin
 {
     public class PenguinStateOnFeet : FsmState
     {
-        private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
 
         private float _locomotionBlend;
         private HorizontalInput _horizontalInput;
 
-        public PenguinStateOnFeet(string name, PenguinFsmDriver driver, PenguinBlob blob)
-            : base(name)
+        public PenguinStateOnFeet(string name, PenguinBlob blob) : base(name)
         {
             _blob = blob;
-            _driver = driver;
         }
 
         protected override void OnIntialize()
@@ -51,7 +48,7 @@ namespace PQ.Entities.Penguin
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
         private void HandleLieDownInputReceived()
         {
-            _driver.MoveToState(PenguinBlob.StateIdLyingDown);
+            base.SignalMoveToNextState(PenguinBlob.StateIdLyingDown);
         }
 
         private void HandleGroundContactChanged(bool isGrounded)
@@ -59,7 +56,7 @@ namespace PQ.Entities.Penguin
             _blob.Animation.SetParamIsGrounded(isGrounded);
             if (!isGrounded)
             {
-                _driver.MoveToState(PenguinBlob.StateIdMidair);
+                base.SignalMoveToNextState(PenguinBlob.StateIdMidair);
             }
         }
 

--- a/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
@@ -8,14 +8,11 @@ namespace PQ.Entities.Penguin
     {
         private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
-        private GameEventCenter _eventCenter;
 
-        public PenguinStateStandingUp(string name, PenguinFsmDriver driver,
-            PenguinBlob blob, GameEventCenter eventCenter) : base(name)
+        public PenguinStateStandingUp(string name, PenguinFsmDriver driver, PenguinBlob blob) : base(name)
         {
             _blob = blob;
             _driver = driver;
-            _eventCenter = eventCenter;
         }
 
         protected override void OnIntialize()

--- a/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
+++ b/Assets/Code/Entities/Penguin/PenguinStateStandingUp.cs
@@ -6,13 +6,11 @@ namespace PQ.Entities.Penguin
 {
     public class PenguinStateStandingUp : FsmState
     {
-        private PenguinFsmDriver _driver;
         private PenguinBlob _blob;
 
-        public PenguinStateStandingUp(string name, PenguinFsmDriver driver, PenguinBlob blob) : base(name)
+        public PenguinStateStandingUp(string name, PenguinBlob blob) : base(name)
         {
             _blob = blob;
-            _driver = driver;
         }
 
         protected override void OnIntialize()
@@ -51,7 +49,7 @@ namespace PQ.Entities.Penguin
                 edgeRadius: 0.68f
             );
 
-            _driver.MoveToState(PenguinBlob.StateIdFeet);
+            base.SignalMoveToNextState(PenguinBlob.StateIdFeet);
 
             // todo: find a good way of having data for sliding and for onFeet that can be passed in here,
             //       and those values can be adjusted, perhaps in their own scriptable objects?

--- a/Assets/Code/GameController.cs
+++ b/Assets/Code/GameController.cs
@@ -15,7 +15,6 @@ namespace PQ
         private GameEventCenter _gameEventCenter;
         private PlayerProgressionInfo _playerInfo;
 
-        // todo: use spawner
         [SerializeField] private GameObject _playerPenguin;
 
         void Awake()
@@ -23,6 +22,8 @@ namespace PQ
             _gameEventCenter = GameEventCenter.Instance;
             _playerPenguin.SetActive(true);
             _gameEventCenter.startNewGame.AddHandler(StartNewGame);
+
+            _playerPenguin.GetComponent<Entities.Penguin.PenguinBlob>().EventBus = _gameEventCenter;
         }
 
         void OnEnable()

--- a/Assets/Code/_Common/Events/PqEvent.cs
+++ b/Assets/Code/_Common/Events/PqEvent.cs
@@ -48,8 +48,8 @@ namespace PQ.Common.Events
         public PqEvent(string name) => _name = name;
 
         public void Raise()                            => _action.Invoke();
-        public void AddHandler(Action onTrigger)       => _action += onTrigger;
-        public void RemoveHandler(Action onTrigger)    => _action -= onTrigger;
+        public void AddHandler(Action onRaise)         => _action += onRaise;
+        public void RemoveHandler(Action onRaise)      => _action -= onRaise;
         bool IEquatable<PqEvent>.Equals(PqEvent other) => other is not null && Name == other.Name;
 
         public override string ToString()         => $"Event({_name})";
@@ -71,8 +71,8 @@ namespace PQ.Common.Events
         public PqEvent(string name) => _name = name;
 
         public void Raise(T args)                            => _action.Invoke(args);
-        public void AddHandler(Action<T> onTrigger)          => _action += onTrigger;
-        public void RemoveHandler(Action<T> onTrigger)       => _action -= onTrigger;
+        public void AddHandler(Action<T> onRaise)            => _action += onRaise;
+        public void RemoveHandler(Action<T> onRaise)         => _action -= onRaise;
         bool IEquatable<PqEvent<T>>.Equals(PqEvent<T> other) => other is not null && Name == other.Name;
 
         public override string ToString()         => $"Event<{typeof(T).FullName}>({_name})";

--- a/Assets/Code/_Common/Fsm/FsmDriver.cs
+++ b/Assets/Code/_Common/Fsm/FsmDriver.cs
@@ -87,6 +87,7 @@ namespace PQ.Common.Fsm
             {
                 throw new InvalidOperationException($"Cannot set initial state to {id} -  was not found");
             }
+
             _initial = initialState;
         }
 
@@ -145,13 +146,13 @@ namespace PQ.Common.Fsm
                 return false;
             }
 
+            _current.Exit();
             _current.OnMoveToLastStateSignaled.RemoveHandler(HandleOnMoveToLastStateSignaled);
             _current.OnMoveToNextStateSignaled.RemoveHandler(HandleOnMoveToNextStateSignaled);
-            _current.Exit();
             OnTransition(_current.Id, _next.Id);
             _next.Enter();
-            _current.OnMoveToLastStateSignaled.AddHandler(HandleOnMoveToLastStateSignaled);
-            _current.OnMoveToNextStateSignaled.AddHandler(HandleOnMoveToNextStateSignaled);
+            _next.OnMoveToLastStateSignaled.AddHandler(HandleOnMoveToLastStateSignaled);
+            _next.OnMoveToNextStateSignaled.AddHandler(HandleOnMoveToNextStateSignaled);
 
             _last    = _current;
             _current = _next;

--- a/Assets/Code/_Common/Fsm/FsmDriver.cs
+++ b/Assets/Code/_Common/Fsm/FsmDriver.cs
@@ -112,6 +112,8 @@ namespace PQ.Common.Fsm
             }
 
             _current = _initial;
+            _current.OnMoveToLastStateSignaled.AddHandler(HandleOnMoveToLastStateSignaled);
+            _current.OnMoveToNextStateSignaled.AddHandler(HandleOnMoveToNextStateSignaled);
             _current.Enter();
         }
 
@@ -132,6 +134,9 @@ namespace PQ.Common.Fsm
         }
 
 
+        private void HandleOnMoveToLastStateSignaled()            => MoveToState(_last.Id);
+        private void HandleOnMoveToNextStateSignaled(string dest) => MoveToState(dest);
+
         // Update our current state provided that it is distinct from the next
         private bool ExecuteTransitionIfPending()
         {
@@ -140,9 +145,13 @@ namespace PQ.Common.Fsm
                 return false;
             }
 
+            _current.OnMoveToLastStateSignaled.RemoveHandler(HandleOnMoveToLastStateSignaled);
+            _current.OnMoveToNextStateSignaled.RemoveHandler(HandleOnMoveToNextStateSignaled);
             _current.Exit();
             OnTransition(_current.Id, _next.Id);
             _next.Enter();
+            _current.OnMoveToLastStateSignaled.AddHandler(HandleOnMoveToLastStateSignaled);
+            _current.OnMoveToNextStateSignaled.AddHandler(HandleOnMoveToNextStateSignaled);
 
             _last    = _current;
             _current = _next;

--- a/Assets/Code/_Common/Fsm/FsmDriver.cs
+++ b/Assets/Code/_Common/Fsm/FsmDriver.cs
@@ -9,6 +9,14 @@ namespace PQ.Common.Fsm
 
     Note that while there is transition validation, the conditions that trigger those
     state changes are up to the specific fsm state implementation.
+
+
+    Note that exceptions are thrown EARLY for invalid driver setup, meaning that if it made it past start
+    with no exceptions, we have unique keys, no nulls in the graph, non empty graphs, explicitly set initial state,
+    and other invariants.
+
+    By doing so as early as Start() being called, this means that we can catch a multitude of developer errors
+    effectively on game load, rather than much later on during game execution.
     */
     public abstract class FsmDriver : MonoBehaviour
     {

--- a/Assets/Code/_Common/Fsm/FsmDriver.cs
+++ b/Assets/Code/_Common/Fsm/FsmDriver.cs
@@ -39,19 +39,19 @@ namespace PQ.Common.Fsm
 
 
         // Update our current state if transition was previously registered during initialization
-        public void MoveToState(string stateId)
+        public void MoveToState(string id)
         {
             if (_next != null)
             {
-                throw new InvalidOperationException($"Cannot move to {stateId} - a transition {_current.Id}=>{_next.Id} is already queued");
+                throw new InvalidOperationException($"Cannot move to {id} - a transition {_current.Id}=>{_next.Id} is already queued");
             }
-            if (!_fsmGraph.TryGetState(stateId, out FsmState next))
+            if (!_fsmGraph.TryGetState(id, out FsmState next))
             {
-                throw new InvalidOperationException($"Cannot move to {stateId} - state {next.Id} was not found");
+                throw new InvalidOperationException($"Cannot move to {id} - state {next.Id} was not found");
             }
-            if (!_fsmGraph.HasTransition(_current.Id, stateId))
+            if (!_fsmGraph.HasTransition(_current.Id, id))
             {
-                throw new InvalidOperationException($"Cannot move to {stateId} - transition {_current.Id}=>{stateId} was not found");
+                throw new InvalidOperationException($"Cannot move to {id} - transition {_current.Id}=>{id} was not found");
             }
 
             _next = next;
@@ -77,15 +77,15 @@ namespace PQ.Common.Fsm
         }
         
         // Override the initial state
-        protected void SetInitialState(string stateId)
+        protected void SetInitialState(string id)
         {
             if (_fsmGraph == null)
             {
-                throw new InvalidOperationException($"Cannot set initial state to {stateId} - graph not yet initialized");
+                throw new InvalidOperationException($"Cannot set initial state to {id} - graph not yet initialized");
             }
-            if (!_fsmGraph.TryGetState(stateId, out FsmState initialState))
+            if (!_fsmGraph.TryGetState(id, out FsmState initialState))
             {
-                throw new InvalidOperationException($"Cannot set initial state to {stateId} -  was not found");
+                throw new InvalidOperationException($"Cannot set initial state to {id} -  was not found");
             }
             _initial = initialState;
         }
@@ -94,7 +94,7 @@ namespace PQ.Common.Fsm
         protected abstract void OnInitialize();
 
         // Optional overridable callback for state transitions
-        protected virtual void OnTransition(string sourceId, string destinationId) { }
+        protected virtual void OnTransition(string source, string dest) { }
 
 
 

--- a/Assets/Code/_Common/Fsm/FsmGraph.cs
+++ b/Assets/Code/_Common/Fsm/FsmGraph.cs
@@ -46,12 +46,12 @@ namespace PQ.Common.Fsm
             _nodes = new Dictionary<string, Node>(states.Length);
             foreach ((FsmState state, string[] _) in states)
             {
-                string stateId = state?.Id;
-                if (string.IsNullOrEmpty(stateId) || _nodes.ContainsKey(stateId))
+                string id = state?.Id;
+                if (string.IsNullOrEmpty(id) || _nodes.ContainsKey(id))
                 {
-                    throw new ArgumentException($"Cannot add {stateId} state to graph - expected non null unique key");
+                    throw new ArgumentException($"Cannot add {id} state to graph - expected non null unique key");
                 }
-                _nodes.Add(key: stateId, value: null);
+                _nodes.Add(id, null);
             }
             
             _nodeCount = 0;
@@ -100,10 +100,10 @@ namespace PQ.Common.Fsm
             return _nodes.ContainsKey(id);
         }
 
-        public bool HasTransition(string source, string destination)
+        public bool HasTransition(string source, string dest)
         {
             return _nodes.ContainsKey(source) &&
-                   _nodes[source].neighbors.Contains(destination);
+                   _nodes[source].neighbors.Contains(dest);
         }
     }
 }

--- a/Assets/Code/_Common/Fsm/FsmGraph.cs
+++ b/Assets/Code/_Common/Fsm/FsmGraph.cs
@@ -49,7 +49,7 @@ namespace PQ.Common.Fsm
                 string id = state?.Id;
                 if (string.IsNullOrEmpty(id) || _nodes.ContainsKey(id))
                 {
-                    throw new ArgumentException($"Cannot add {id} state to graph - expected non null unique key");
+                    throw new ArgumentException($"Cannot add state {id} to graph - expected non null unique key");
                 }
                 _nodes.Add(id, null);
             }

--- a/Assets/Code/_Common/Fsm/FsmState.cs
+++ b/Assets/Code/_Common/Fsm/FsmState.cs
@@ -24,8 +24,8 @@ namespace PQ.Common.Fsm
         private bool _initialized;
         private PqEventRegistry _eventRegistry;
 
-        private PqEvent<string>           _moveToLastStateRequest = new("fsm.state.move.last");
-        private PqEvent<(string, string)> _moveToNextStateRequest = new("fsm.state.move.next");
+        private PqEvent         _moveToLastStateRequest = new("fsm.state.move.last");
+        private PqEvent<string> _moveToNextStateRequest = new("fsm.state.move.next");
 
         public string Id;
         public bool IsActive => _active;
@@ -51,8 +51,8 @@ namespace PQ.Common.Fsm
             _eventRegistry = new();
         }
 
-        public void OnMoveToLastStateSignaled(Action<string> onTrigger)           => _moveToLastStateRequest.AddHandler(onTrigger);
-        public void OnMoveToNextStateSignaled(Action<(string, string)> onTrigger) => _moveToNextStateRequest.AddHandler(onTrigger);
+        public IPqEventReceiver         OnMoveToLastStateSignaled => _moveToLastStateRequest;
+        public IPqEventReceiver<string> OnMoveToNextStateSignaled => _moveToNextStateRequest;
 
         // Entry point for client code initializing state instances
         // Any 'startup' code such as hooking up handlers to events is done here
@@ -103,8 +103,8 @@ namespace PQ.Common.Fsm
         // Mechanism for hooking up events to handlers such that they can automatically be subscribed on state enter
         // and unsubscribed on state exit.
         // Can only be invoked in OnInitialize.
-        protected void SignalMoveToLastState() => _moveToLastStateRequest.Raise(_id);
-        protected void SignalMoveToNextState(string destinationStateId) => _moveToNextStateRequest.Raise((_id, destinationStateId));
+        protected void SignalMoveToLastState()            => _moveToLastStateRequest.Raise();
+        protected void SignalMoveToNextState(string dest) => _moveToNextStateRequest.Raise(dest);
         protected void RegisterEvent(IPqEventReceiver event_, Action handler_)          => _eventRegistry.Add(event_, handler_);
         protected void RegisterEvent<T>(IPqEventReceiver<T> event_, Action<T> handler_) => _eventRegistry.Add(event_, handler_);
 


### PR DESCRIPTION
# Make fsm setup simpler and more robust

## Overview
### The Why
Eventually we want to move the construction of states fully into driver and graph, and use a blackboard style 'data bus' for any persistent data dependencies for states. That means streamlining constructor calls/creation logic as much as we reasonably can.

And why do we want those things in the first place? Well, the whole idea behind all the recent changes like auto subscribe/unsubscribe of events, and these future data changes is to reduce boilerplate and code duplication such that game logic included in any given states implementation is crystal clear.

### The What 
Greatly simplifies state initialization and makes things more robust by:
* Moving penguin dependencies into blob (ie eventBus) and providing a base GenericBlob for new entities to do the same
* Reworking fsm architecture to rely on events for signaling transitions instead of direct calls to `FsmDriver.MoveToState()`
* Requiring explicit designation of initial state in driver subclasses via `SetInitialState()`


## Detailed Changelog
* Move event center into blob and create a generic one
* Remove driver dependency from penguin substates
* Change source/destination and id/stateId verbiage to be consistent
* Change event handler param naming from from onTrigger to onRaise for consistency
* Fix transition logic flow in driver
* Strictly enforce uniform enter/exit/initialize with thorough exception checking in driver
* Update driver API docs
* Prevent exception on editor stop by checking event bus for disconnect ONLY if currently play in editor**

**Since Start() is invoked twice for execute always scripts, and the event bus is the only 'gameplay logic' in the penguin blob, we need to perform the check only when play is started, so that means special casing for active play in Unity editor mode.
