### PR TITLE
Rework state machine such that enums are used as array indices

### DIFF
--- a/Assets/Code/Entities/Penguin/Components/PenguinStateId.cs
+++ b/Assets/Code/Entities/Penguin/Components/PenguinStateId.cs
@@ -1,16 +1,13 @@
-using System;
 
 
 namespace PQ.Entities.Penguin
 {
-    [Flags]
     public enum PenguinStateId
     {
-        None       = 0,
-        Feet       = 1 << 1,
-        Belly      = 1 << 2,
-        StandingUp = 1 << 3,
-        LyingDown  = 1 << 4,
-        Midair     = 1 << 5,
+        Feet,
+        Belly,
+        StandingUp,
+        LyingDown,
+        Midair,
     }
 }

--- a/Assets/Code/Entities/Penguin/Components/PenguinStateId.cs
+++ b/Assets/Code/Entities/Penguin/Components/PenguinStateId.cs
@@ -6,10 +6,11 @@ namespace PQ.Entities.Penguin
     [Flags]
     public enum PenguinStateId
     {
-        Feet       = 0,
-        Belly      = 1 << 1,
-        StandingUp = 1 << 2,
-        LyingDown  = 1 << 3,
-        Midair     = 1 << 4,
+        None       = 0,
+        Feet       = 1 << 1,
+        Belly      = 1 << 2,
+        StandingUp = 1 << 3,
+        LyingDown  = 1 << 4,
+        Midair     = 1 << 5,
     }
 }

--- a/Assets/Code/Entities/Penguin/PenguinBlob.cs
+++ b/Assets/Code/Entities/Penguin/PenguinBlob.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.Contracts;
 using UnityEngine;
 using PQ.Common.Fsm;
+using PQ.Common.Extensions;
 
 
 namespace PQ.Entities.Penguin
@@ -117,7 +118,7 @@ namespace PQ.Entities.Penguin
         #if UNITY_EDITOR
         void OnDrawGizmos()
         {
-            Common.Extensions.GizmoExtensions.DrawSphere(_penguinAnimation.SkeletalRootPosition, 1.00f, Color.white);
+            GizmoExtensions.DrawSphere(_penguinAnimation.SkeletalRootPosition, 1.00f, Color.white);
         }
         #endif
         
@@ -209,7 +210,7 @@ namespace PQ.Entities.Penguin
         private static bool HasAllFlags(PenguinColliderConstraints constraints, PenguinColliderConstraints flags)
         {
             // check if ALL given flags are a proper subset of constraints
-            return (constraints & flags) == flags;
+            return EnumExtensions.HasAllFlags(constraints, flags);
         }
     }
 }

--- a/Assets/Code/Entities/Penguin/PenguinBlob.cs
+++ b/Assets/Code/Entities/Penguin/PenguinBlob.cs
@@ -210,7 +210,7 @@ namespace PQ.Entities.Penguin
         private static bool HasAllFlags(PenguinColliderConstraints constraints, PenguinColliderConstraints flags)
         {
             // check if ALL given flags are a proper subset of constraints
-            return EnumExtensions.HasAllFlags(constraints, flags);
+            return EnumExtensions.HasFlags(constraints, flags);
         }
     }
 }

--- a/Assets/Code/Entities/Penguin/PenguinBlob.cs
+++ b/Assets/Code/Entities/Penguin/PenguinBlob.cs
@@ -163,13 +163,13 @@ namespace PQ.Entities.Penguin
 
         private void UpdateColliderEnabilityAccordingToConstraints(PenguinColliderConstraints constraints)
         {
-            _headCollider             .enabled = !HasAllFlags(constraints, PenguinColliderConstraints.DisableHead);
-            _torsoCollider            .enabled = !HasAllFlags(constraints, PenguinColliderConstraints.DisableTorso);
-            _frontFlipperUpperCollider.enabled = !HasAllFlags(constraints, PenguinColliderConstraints.DisableFlippers);
-            _frontFlipperLowerCollider.enabled = !HasAllFlags(constraints, PenguinColliderConstraints.DisableFlippers);
-            _frontFootCollider        .enabled = !HasAllFlags(constraints, PenguinColliderConstraints.DisableFeet);
-            _backFootCollider         .enabled = !HasAllFlags(constraints, PenguinColliderConstraints.DisableFeet);
-            _outerCollider            .enabled = !HasAllFlags(constraints, PenguinColliderConstraints.DisableOuter);
+            _headCollider             .enabled = !IsDisabled(constraints, PenguinColliderConstraints.DisableHead);
+            _torsoCollider            .enabled = !IsDisabled(constraints, PenguinColliderConstraints.DisableTorso);
+            _frontFlipperUpperCollider.enabled = !IsDisabled(constraints, PenguinColliderConstraints.DisableFlippers);
+            _frontFlipperLowerCollider.enabled = !IsDisabled(constraints, PenguinColliderConstraints.DisableFlippers);
+            _frontFootCollider        .enabled = !IsDisabled(constraints, PenguinColliderConstraints.DisableFeet);
+            _backFootCollider         .enabled = !IsDisabled(constraints, PenguinColliderConstraints.DisableFeet);
+            _outerCollider            .enabled = !IsDisabled(constraints, PenguinColliderConstraints.DisableOuter);
         }
 
         private PenguinColliderConstraints GetConstraintsAccordingToDisabledColliders()
@@ -207,10 +207,11 @@ namespace PQ.Entities.Penguin
         }
 
         [Pure]
-        private static bool HasAllFlags(PenguinColliderConstraints constraints, PenguinColliderConstraints flags)
+        private static bool IsDisabled(PenguinColliderConstraints constraints, PenguinColliderConstraints flags)
         {
             // check if ALL given flags are a proper subset of constraints
-            return EnumExtensions.HasFlags(constraints, flags);
+            // note that unlike enum.hasFlags, this returns false for None = 0
+            return (constraints & flags) == flags;
         }
     }
 }

--- a/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
+++ b/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
@@ -7,7 +7,7 @@ namespace PQ.Entities.Penguin
     public sealed class PenguinFsmDriver : FsmDriver<PenguinStateId, PenguinBlob>
     {
         protected override void OnInitialStateEntered(PenguinStateId initial) =>
-            Debug.Log($"Entered initial state\n{this}");
+            Debug.Log($"Intialized {this}");
 
         protected override void OnTransition(PenguinStateId source, PenguinStateId dest) =>
             Debug.Log($"Transitioning Penguin from {source} to {dest}");

--- a/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
+++ b/Assets/Code/Entities/Penguin/PenguinFsmDriver.cs
@@ -7,7 +7,7 @@ namespace PQ.Entities.Penguin
     public sealed class PenguinFsmDriver : FsmDriver<PenguinStateId, PenguinBlob>
     {
         protected override void OnInitialStateEntered(PenguinStateId initial) =>
-            Debug.Log($"Entered initial state");
+            Debug.Log($"Entered initial state\n{this}");
 
         protected override void OnTransition(PenguinStateId source, PenguinStateId dest) =>
             Debug.Log($"Transitioning Penguin from {source} to {dest}");

--- a/Assets/Code/_Common/Containers.meta
+++ b/Assets/Code/_Common/Containers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cdde8f0b354fc864ba25ac7df881ea16
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/_Common/Containers/BitSet.cs
+++ b/Assets/Code/_Common/Containers/BitSet.cs
@@ -1,0 +1,90 @@
+﻿using System;
+
+
+namespace PQ.Common.Extensions
+{
+    /*
+    Fixed size array of bits.
+
+    Unlike C#'s BitVector32 collection, this is more similar to C++'s bitset, with more support
+    for checking non-contiguous subsets (as opposed to BitVector32.Section).
+    */
+    public struct BitSet : IEquatable<BitSet>, IComparable<BitSet>
+    {
+        public int Value    { get; private set; }
+        public int SetCount { get; private set; }
+        public int Length   { get; private set; }
+        
+
+        public BitSet(int length)
+        {            
+            if (length < 0)
+            {
+                throw new ArgumentException($"Bitset size cannot be negative");
+            }            
+            Value    = 0;
+            SetCount = 0;
+            Length   = length;
+        }
+
+        public bool TryAdd(int index)
+        {
+            int element = 1 << index;
+            if (index < 0 || index >= Length || (Value & element) != 0)
+            {
+                return false;
+            }
+
+            Value |= element;
+            SetCount++;
+            return true;
+        }
+
+        public bool TryRemove(int index)
+        {
+            int element = 1 << index;
+            if (index < 0 || index >= Length || (Value & element) == 0)
+            {
+                return false;
+            }
+
+            Value &= element;
+            SetCount--;
+            return true;
+        }
+
+        public bool IsSet(int index)
+        {
+            // note that no index check is necessary since that's enforced in Set()
+            return (Value & (1 << index)) != 0;
+        }
+
+        public bool IsSubset(int mask)
+        {
+            // explicitly check against given mask to ensure that zero
+            // is not included unless the mask is as well
+            return (Value & mask) == mask;
+        }
+
+        public static string ToString(BitSet bitSet)
+        {
+            var bits = new char[bitSet.Length];
+            for (int i = 0; i < bits.Length; i++)
+            {
+                bits[i] = bitSet.IsSet(i) ? '1' : '0';
+            }
+            return new string(bits);
+        }
+
+        
+        public override string  ToString()         => ToString(bitSet: this);
+        public override int     GetHashCode()      => HashCode.Combine(Value);
+        public override bool    Equals(object obj) => obj is BitSet && Equals((BitSet)obj);
+
+        bool IEquatable<BitSet>.Equals(BitSet other)    => Value == other.Value;
+        int IComparable<BitSet>.CompareTo(BitSet other) => Value.CompareTo(other.Value);
+
+        public static bool operator ==(BitSet left, BitSet right) => left.Value == right.Value;
+        public static bool operator !=(BitSet left, BitSet right) => left.Value != right.Value;
+    }
+}

--- a/Assets/Code/_Common/Containers/BitSet.cs
+++ b/Assets/Code/_Common/Containers/BitSet.cs
@@ -11,52 +11,52 @@ namespace PQ.Common.Extensions
     */
     public struct BitSet : IEquatable<BitSet>, IComparable<BitSet>
     {
-        public int Value    { get; private set; }
-        public int SetCount { get; private set; }
-        public int Length   { get; private set; }
+        public int Value { get; private set; }
+        public int Count { get; private set; }
+        public int Size  { get; private set; }
         
 
-        public BitSet(int length)
+        public BitSet(int size)
         {            
-            if (length < 0)
+            if (size < 0)
             {
                 throw new ArgumentException($"Bitset size cannot be negative");
-            }            
-            Value    = 0;
-            SetCount = 0;
-            Length   = length;
+            }
+            Value = 0;
+            Count = 0;
+            Size  = size;
         }
 
-        public bool TryAdd(int index)
+        public bool TryAdd(int bitPosition)
         {
-            int element = 1 << index;
-            if (index < 0 || index >= Length || (Value & element) != 0)
+            int element = 1 << bitPosition;
+            if (bitPosition < 0 || bitPosition >= Size || (Value & element) != 0)
             {
                 return false;
             }
 
             Value |= element;
-            SetCount++;
+            Count++;
             return true;
         }
 
-        public bool TryRemove(int index)
+        public bool TryRemove(int bitPosition)
         {
-            int element = 1 << index;
-            if (index < 0 || index >= Length || (Value & element) == 0)
+            int element = 1 << bitPosition;
+            if (bitPosition < 0 || bitPosition >= Size || (Value & element) == 0)
             {
                 return false;
             }
 
             Value &= element;
-            SetCount--;
+            Count--;
             return true;
         }
 
-        public bool IsSet(int index)
+        public bool IsSet(int bitPosition)
         {
             // note that no index check is necessary since that's enforced in Set()
-            return (Value & (1 << index)) != 0;
+            return (Value & (1 << bitPosition)) != 0;
         }
 
         public bool IsSubset(int mask)
@@ -66,9 +66,16 @@ namespace PQ.Common.Extensions
             return (Value & mask) == mask;
         }
 
+        public bool IsSubset(BitSet bitSet)
+        {
+            // explicitly check against given mask to ensure that zero
+            // is not included unless the mask is as well
+            return (Value & bitSet.Value) == bitSet.Value;
+        }
+
         public static string ToString(BitSet bitSet)
         {
-            var bits = new char[bitSet.Length];
+            var bits = new char[bitSet.Size];
             for (int i = 0; i < bits.Length; i++)
             {
                 bits[i] = bitSet.IsSet(i) ? '1' : '0';

--- a/Assets/Code/_Common/Containers/BitSet.cs.meta
+++ b/Assets/Code/_Common/Containers/BitSet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a48b4606abe7f4646a1a8fe77a7cd7dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/_Common/Events/PqEventRegistry.cs
+++ b/Assets/Code/_Common/Events/PqEventRegistry.cs
@@ -126,11 +126,11 @@ namespace PQ.Common.Events
             if (_entries.Count > 0)
             {
 
-                _stringBuilder.Append(entry.Description);
+                _stringBuilder.Append(',').Append(entry.Description);
             }
             else
             {
-                _stringBuilder.Append(',').Append(entry.Description);
+                _stringBuilder.Append(entry.Description);
             }
 
             _description = _stringBuilder.ToString();

--- a/Assets/Code/_Common/Fsm/FsmDriver.cs
+++ b/Assets/Code/_Common/Fsm/FsmDriver.cs
@@ -20,7 +20,7 @@ namespace PQ.Common.Fsm
     effectively on game load, rather than much later on during game execution.
     */
     public abstract class FsmDriver<StateId, SharedData> : MonoBehaviour
-        where StateId    : Enum
+        where StateId    : struct, Enum
         where SharedData : FsmSharedData
     {
         private bool _initialized;

--- a/Assets/Code/_Common/Fsm/FsmDriver.cs
+++ b/Assets/Code/_Common/Fsm/FsmDriver.cs
@@ -80,10 +80,6 @@ namespace PQ.Common.Fsm
             {
                 throw new InvalidOperationException($"Cannot initialize - builder cannot be null");
             }
-            if (builder == null)
-            {
-                throw new InvalidOperationException($"Cannot initialize - builder cannot be null");
-            }
 
             _initialized = true;
             _graph       = new FsmGraph<StateId, SharedData>(builder.nodes);

--- a/Assets/Code/_Common/Fsm/FsmDriver.cs
+++ b/Assets/Code/_Common/Fsm/FsmDriver.cs
@@ -41,8 +41,7 @@ namespace PQ.Common.Fsm
                     $"current:{_current?.Name ?? "<none>"}," +
                     $"last:{_last?.Name ?? "<none>"}," +
                     $"next:{_next?.Name ?? "<none>"})" +
-                $"\n  {_graph}" +
-            $"}}";
+                $"\n{_graph}";
         }
 
 

--- a/Assets/Code/_Common/Fsm/FsmDriver.cs
+++ b/Assets/Code/_Common/Fsm/FsmDriver.cs
@@ -32,17 +32,18 @@ namespace PQ.Common.Fsm
         private FsmState<StateId, SharedData> _next;
         private FsmState<StateId, SharedData> _current;
 
-        public override string ToString() =>
-            $"FsmDriver:{{" +
-                $"\nFsmData({_sharedData}), " +
-                $"\nFsmHistory(" +
-                    $"initial:{_initial.Id}," +
-                    $"current:{_current.Id}," +
-                    $"last:{_last.Id}," +
-                    $"next:{_next.Id})" +
-                $"{_graph}" +
+        public override string ToString()
+        {
+            return
+                $"{GetType()}(gameObject:{base.name},data:{_sharedData})" +
+                $"\n  FsmHistory(" +
+                    $"initial:{_initial?.Name ?? "<none>"}," +
+                    $"current:{_current?.Name ?? "<none>"}," +
+                    $"last:{_last?.Name ?? "<none>"}," +
+                    $"next:{_next?.Name ?? "<none>"})" +
+                $"\n  {_graph}" +
             $"}}";
-
+        }
 
 
         /*** Internal Hooks for Setting up a Specific State Machine Instance ***/

--- a/Assets/Code/_Common/Fsm/FsmGraph.cs
+++ b/Assets/Code/_Common/Fsm/FsmGraph.cs
@@ -36,7 +36,7 @@ namespace PQ.Common.Fsm
         public int StateCount => _nodeCount;
         public int TransitionCount => _edgeCount;
 
-        private const int indentAmount = 2;
+        private const int indentAmount = 4;
         
         public override string ToString() => _description;
 
@@ -64,10 +64,8 @@ namespace PQ.Common.Fsm
 
             _nodeCount = 0;
             _edgeCount = 0;
-            string indent1 = new(' ', indentAmount);
-            string indent2 = new(' ', indentAmount * 2);
-            StringBuilder nodesInfo = new($"{indent1}states\n");
-            StringBuilder edgesInfo = new($"{indent1}transitions\n");
+            string indent = new(' ', indentAmount);
+            StringBuilder stringBuilder = new();
             foreach ((FsmState<StateId, SharedData> state, StateId[] destinations) in states)
             {
                 StateId source = state.Id;
@@ -84,15 +82,14 @@ namespace PQ.Common.Fsm
                 }
 
                 state.Initialize();
-                nodesInfo.Append($"{indent2}{state}").AppendLine();
-                edgesInfo.Append($"{indent2}{source} => {{").AppendJoin(",", neighbors).Append($"}}").AppendLine();
+                stringBuilder.Append($"{indent}{source}=>{{").AppendJoin(",", neighbors).Append($"}}").AppendLine();
 
                 _nodeCount++;
                 _edgeCount += neighbors.Count;
                 _nodes[source] = new(state, neighbors);
             }
 
-            _description = $"FsmGraph({_nodeCount} states, {_edgeCount} transitions)\n{nodesInfo}\n{edgesInfo}";
+            _description = $"{{\n{stringBuilder}}}";
         }
 
         public bool HasState(StateId id) =>

--- a/Assets/Code/_Common/Fsm/FsmGraph.cs
+++ b/Assets/Code/_Common/Fsm/FsmGraph.cs
@@ -28,11 +28,15 @@ namespace PQ.Common.Fsm
             }
         }
 
-        private readonly Type _idType;
         private readonly int _nodeCount;
         private readonly int _edgeCount;
         private readonly string _description;
         private readonly Dictionary<StateId, Node> _nodes;
+
+        public int StateCount => _nodeCount;
+        public int TransitionCount => _edgeCount;
+
+        private const int indentAmount = 2;
         
         public override string ToString() => _description;
 
@@ -58,11 +62,12 @@ namespace PQ.Common.Fsm
                 _nodes.Add(id, null);
             }
 
-            _idType = typeof(StateId);
             _nodeCount = 0;
             _edgeCount = 0;
-            StringBuilder nodesInfo = new($" states");
-            StringBuilder edgesInfo = new($" transitions");
+            string indent1 = new(' ', indentAmount);
+            string indent2 = new(' ', indentAmount * 2);
+            StringBuilder nodesInfo = new($"{indent1}states\n");
+            StringBuilder edgesInfo = new($"{indent1}transitions\n");
             foreach ((FsmState<StateId, SharedData> state, StateId[] destinations) in states)
             {
                 StateId source = state.Id;
@@ -79,15 +84,15 @@ namespace PQ.Common.Fsm
                 }
 
                 state.Initialize();
-                nodesInfo.Append($"   ").AppendLine(state.ToString());
-                edgesInfo.Append($"   {source} => {{").AppendJoin(",", neighbors).Append($"}}").AppendLine();
+                nodesInfo.Append($"{indent2}{state}").AppendLine();
+                edgesInfo.Append($"{indent2}{source} => {{").AppendJoin(",", neighbors).Append($"}}").AppendLine();
 
                 _nodeCount++;
                 _edgeCount += neighbors.Count;
                 _nodes[source] = new(state, neighbors);
             }
 
-            _description = $"FsmGraph({_nodeCount} states, {_edgeCount} transitions) \n{nodesInfo} \n{edgesInfo}";
+            _description = $"FsmGraph({_nodeCount} states, {_edgeCount} transitions)\n{nodesInfo}\n{edgesInfo}";
         }
 
         public bool HasState(StateId id) =>
@@ -96,6 +101,6 @@ namespace PQ.Common.Fsm
             _nodes.ContainsKey(source) && _nodes[source].neighbors.Contains(dest);
 
         public FsmState<StateId, SharedData> GetState(StateId id) =>
-            Enum.IsDefined(_idType, id) && _nodes.ContainsKey(id) ? _nodes[id].state : null;
+            _nodes.ContainsKey(id) ? _nodes[id].state : null;
     }
 }

--- a/Assets/Code/_Common/Fsm/FsmGraph.cs
+++ b/Assets/Code/_Common/Fsm/FsmGraph.cs
@@ -13,7 +13,7 @@ namespace PQ.Common.Fsm
     Also, states cannot have edges that loop directly back to itself.
     */
     internal sealed class FsmGraph<StateId, SharedData>
-        where StateId    : Enum
+        where StateId    : struct, Enum
         where SharedData : FsmSharedData
     {
         private sealed class Node

--- a/Assets/Code/_Common/Fsm/FsmSharedData.cs
+++ b/Assets/Code/_Common/Fsm/FsmSharedData.cs
@@ -11,6 +11,6 @@ namespace PQ.Common.Fsm
     [ExecuteAlways]
     public abstract class FsmSharedData : MonoBehaviour
     {
-
+        public override string ToString() => $"{GetType()}";
     }
 }

--- a/Assets/Code/_Common/Fsm/FsmState.cs
+++ b/Assets/Code/_Common/Fsm/FsmState.cs
@@ -22,7 +22,7 @@ namespace PQ.Common.Fsm
         : IEquatable <FsmState<StateId, SharedData>>,
           IComparable<FsmState<StateId, SharedData>>
         where SharedData : FsmSharedData
-        where StateId    : Enum
+        where StateId    : struct, Enum
     {
         private StateId         _id;
         private SharedData      _data;

--- a/Assets/Code/_Common/Fsm/FsmState.cs
+++ b/Assets/Code/_Common/Fsm/FsmState.cs
@@ -25,6 +25,7 @@ namespace PQ.Common.Fsm
         where StateId    : struct, Enum
     {
         private StateId         _id;
+        private string          _name;
         private SharedData      _data;
         private bool            _active;
         private PqEventRegistry _eventRegistry;
@@ -36,6 +37,7 @@ namespace PQ.Common.Fsm
         private static readonly EqualityComparer<StateId> IdEqualityComparer = EqualityComparer<StateId>.Default;
 
         public    StateId    Id     => _id;
+        public    string     Name   => _name;
         protected SharedData Blob   => _data;
         public    bool       Active => _active;
         public IPqEventReceiver          OnMoveToLastStateSignaled => _moveToLastStateSignal;
@@ -68,6 +70,7 @@ namespace PQ.Common.Fsm
             return new()
             {
                 _id = id,
+                _name = id.ToString(),
                 _data = blob,
                 _active = false,
                 _eventRegistry = new(),

--- a/Assets/Code/_Common/Fsm/FsmState.cs
+++ b/Assets/Code/_Common/Fsm/FsmState.cs
@@ -67,10 +67,11 @@ namespace PQ.Common.Fsm
         public static StateSubclassInstance Create<StateSubclassInstance>(StateId id, SharedData blob)
             where StateSubclassInstance : FsmState<StateId, SharedData>, new()
         {
+            new UnityEngine.Vector3();
             return new()
             {
                 _id = id,
-                _name = id.ToString(),
+                _name = Enum.GetName(typeof(StateId), id),
                 _data = blob,
                 _active = false,
                 _eventRegistry = new(),

--- a/Assets/Code/_Common/_Extensions/EnumExtensions.cs
+++ b/Assets/Code/_Common/_Extensions/EnumExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Diagnostics.Contracts;
+using Unity.Collections.LowLevel.Unsafe;
+
+
+namespace PQ.Common.Extensions
+{
+    /*
+    Collection of utilities for working with generic enums.
+
+    Unlike much of the Enum utilities provided in System.Enum, via generic constraints and unsafe conversions,
+    we get boxing-free (eg no garbage) highly performant conversions and bit flag operations.
+    */
+    public static class EnumExtensions
+    {
+        [Pure] public static bool IsDefined<T>(T value) where T : struct, Enum => Enum.IsDefined(typeof(T), value);
+
+
+        [Pure] public static int AsInt<T>(T value)    where T : struct, Enum => UnsafeUtility.As<T, int>(ref value);
+
+        [Pure] public static T   AsEnum<T>(int value) where T : struct, Enum => UnsafeUtility.As<int, T>(ref value);
+
+
+        [Pure] public static string NameOf<T>()                 where T : struct, Enum => nameof(T);
+
+        [Pure] public static string NameOf<T>(T value)          where T : struct, Enum => nameof(value);
+
+        [Pure] public static string FullNameOfValue<T>(T value) where T : struct, Enum => $"{nameof(T)}.{nameof(value)}";
+
+        
+        // check if ALL given flags are a proper subset of constraints
+        // note that unlike enum.hasFlags, this returns false for None = 0
+        [Pure]
+        public static bool HasAllFlags<T>(T constraints, T flags)
+            where T : struct, Enum
+        {
+            var constraints_ = AsInt(constraints);
+            var flags_       = AsInt(flags);
+            return (constraints_ & flags_) == flags_;
+        }
+    }
+}

--- a/Assets/Code/_Common/_Extensions/EnumExtensions.cs
+++ b/Assets/Code/_Common/_Extensions/EnumExtensions.cs
@@ -10,6 +10,9 @@ namespace PQ.Common.Extensions
 
     Unlike much of the Enum utilities provided in System.Enum, via generic constraints and unsafe conversions,
     we get boxing-free (eg no garbage) highly performant conversions and bit flag operations.
+
+    Caution: For the sake of performance, all methods assume underlying type is the default int32, and that
+             system.flags is used as an attribute, with default value of none
     */
     public static class EnumExtensions
     {
@@ -27,16 +30,33 @@ namespace PQ.Common.Extensions
 
         [Pure] public static string FullNameOfValue<T>(T value) where T : struct, Enum => $"{nameof(T)}.{nameof(value)}";
 
-        
+
+        [Pure] public static T SetFlags<T>(T set, T subset)   where T : struct, Enum => AsEnum<T>(AsInt(set) | AsInt(subset));
+        [Pure] public static T ClearFlags<T>(T set, T subset) where T : struct, Enum => AsEnum<T>(AsInt(set) & AsInt(subset));
+
+
         // check if ALL given flags are a proper subset of constraints
         // note that unlike enum.hasFlags, this returns false for None = 0
         [Pure]
-        public static bool HasAllFlags<T>(T constraints, T flags)
+        public static bool HasFlags<T>(T set, T subset)
             where T : struct, Enum
         {
-            var constraints_ = AsInt(constraints);
-            var flags_       = AsInt(flags);
-            return (constraints_ & flags_) == flags_;
+            var set_    = AsInt(set);
+            var subset_ = AsInt(subset);
+            return (set_ & subset_) == subset_;
+        }
+
+        // OR all given flags together
+        [Pure]
+        public static T CombineFlags<T>(in T[] subsets)
+            where T : struct, Enum
+        {
+            int bits = 0;
+            for (int i = 0; i < subsets.Length; i++)
+            {
+                bits |= AsInt(subsets[i]);
+            }
+            return AsEnum<T>(bits);
         }
     }
 }

--- a/Assets/Code/_Common/_Extensions/EnumExtensions.cs.meta
+++ b/Assets/Code/_Common/_Extensions/EnumExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee10b825c3b7c784fa3066e8973a743c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Rework state machine such that enums are used as array indices

### Overview
Building off of [PR #129 Rework state machine such that enums are used as keys instead of strings](https://github.com/jeffreypersons/Penguin-Quest/pull/129).

Now we can use plain enums as keys, with no more need for hashsets or dictionaries, as we use a custom `BitSet` value type for that - meaning constant space and much less lookup overhead and gc pressure!


### Changelog
* Extract out a custom `BitSet` container for constant space lookups, and replace id sets/dicts with it
* Implement and utilize new enum extensions for garbage free conversions (ie no boxing alternatives to Enum methods)
* Improve `toString()` indentation and formatting for all state machine components
* Change all state id generic params to value type (`where T : struct, Enum`) thus keeping things on the stack and non-null
