### PR TITLE
Streamline enum map and set APIs

### DIFF
--- a/Assets/Code/Common/Containers/EnumMap.cs
+++ b/Assets/Code/Common/Containers/EnumMap.cs
@@ -40,13 +40,13 @@ namespace PQ.Common.Containers
         // todo: look into returning cached enumerators instead...
 
         /* Get a copy of each added field in the set (in their enum defined order) */
-        public IReadOnlyList<TKey> Keys => ExtractAddedKeys(_keys).ToArray();
+        public IReadOnlyList<TKey> Keys => ExtractKeys(_keys).ToArray();
 
         /* Get a copy of each added value in the set (in their key's enum defined order) */
-        public IReadOnlyList<TValue> Values => ExtractAddedValues(_keys, _values).ToArray();
+        public IReadOnlyList<TValue> Values => ExtractValues(_keys, _values).ToArray();
 
         /* Get a copy of each added {field, value} in the set (in their enum defined order) */
-        public IReadOnlyList<(TKey key, TValue value)> Entries => ExtractAddedEntries(_keys, _values).ToArray();
+        public IReadOnlyList<(TKey key, TValue value)> Entries => ExtractEntries(_keys, _values).ToArray();
 
         /* What are all the fields defined in the backing enum, in order? */
         public IReadOnlyList<TKey> EnumFields => _keys.EnumFields;
@@ -71,7 +71,7 @@ namespace PQ.Common.Containers
         public override string ToString()
         {
             return $"{typeof(EnumMap<TKey, TValue>).Name}<{typeof(TKey)},{typeof(TValue)}>" +
-                   $"{{ {string.Join(", ", ExtractAddedValues(_keys, _values))} }}";
+                   $"{{ {string.Join(", ", ExtractValues(_keys, _values))} }}";
         }
 
         /* Is key included in our set of keys? */
@@ -173,7 +173,7 @@ namespace PQ.Common.Containers
 
         // todo: investigate just how much garbage these are creating, and consider replacing with list style enumerator struct
 
-        private static IEnumerable<TKey> ExtractAddedKeys(EnumSet<TKey> keys)
+        private static IEnumerable<TKey> ExtractKeys(EnumSet<TKey> keys)
         {
             for (int i = 0; i < keys.Size; i++)
             {
@@ -184,7 +184,7 @@ namespace PQ.Common.Containers
             }
         }
 
-        private static IEnumerable<TValue> ExtractAddedValues(EnumSet<TKey> keys, TValue[] values)
+        private static IEnumerable<TValue> ExtractValues(EnumSet<TKey> keys, TValue[] values)
         {
             for (int i = 0; i < keys.Size; i++)
             {
@@ -195,7 +195,7 @@ namespace PQ.Common.Containers
             }
         }
 
-        private static IEnumerable<(TKey key, TValue value)> ExtractAddedEntries(EnumSet<TKey> keys, TValue[] values)
+        private static IEnumerable<(TKey key, TValue value)> ExtractEntries(EnumSet<TKey> keys, TValue[] values)
         {
             for (int i = 0; i < keys.Size; i++)
             {

--- a/Assets/Code/Common/Fsm/FsmGraph.cs
+++ b/Assets/Code/Common/Fsm/FsmGraph.cs
@@ -80,7 +80,7 @@ namespace PQ.Common.Fsm
 
             var id = state.Id;
             var neighbors = new EnumSet<StateId>(adjacents);
-            if (!_nodes.Add(id, new Node(state, neighbors)))
+            if (!_nodes.TryAdd(id, new Node(state, neighbors)))
             {
                 throw new ArgumentException($"Cannot add node - {id} is not a defined {typeof(StateId)} enum");
             }


### PR DESCRIPTION
# Streamline enum map and set APIs
Brings them to parity with each other, improvements such as:
* Standarize naming and method ordering
* Proper hiding of index-based methods (cannot be accessed outside `Common` assembly such that we avoid relying on indices in client code
* Reduce complexity of nested calls (previously, adding a new entry via map meant over 6 nested calls between the two classes!) reducing this meant a little added code duplication, but in this case it's not too bad and the smaller callstack makes that a worthwhile tradeoff to make
