### PR TITLE
Match param id names exactly to animator and enforce it

### DIFF
--- a/Assets/Code/Common/Containers/EnumMap.cs
+++ b/Assets/Code/Common/Containers/EnumMap.cs
@@ -52,14 +52,18 @@ namespace PQ.Common.Containers
         public IReadOnlyList<TKey> EnumFields => _keys.EnumFields;
 
 
-        public EnumMap(in (TKey key, TValue value)[] entries=null)
+
+        public EnumMap()
         {
             _keys   = new EnumSet<TKey>();
             _values = new TValue[_keys.Size];
+        }
 
+        public EnumMap(in (TKey key, TValue value)[] entries) : this()
+        {
             if (entries == null)
             {
-                return;
+                throw new ArgumentNullException($"Failed to add entries - cannot be null");
             }
 
             foreach ((TKey key, TValue value) in entries)
@@ -67,6 +71,7 @@ namespace PQ.Common.Containers
                 Add(key, value);
             }
         }
+
 
         public override string ToString()
         {

--- a/Assets/Code/Common/Containers/EnumMap.cs
+++ b/Assets/Code/Common/Containers/EnumMap.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.Reflection;
 
 
 namespace PQ.Common.Containers

--- a/Assets/Code/Common/Containers/EnumMetadata.cs
+++ b/Assets/Code/Common/Containers/EnumMetadata.cs
@@ -5,6 +5,14 @@ using System.Diagnostics.Contracts;
 using Unity.Collections.LowLevel.Unsafe;
 
 
+//
+// *** todo: look into serializable enum name support ***
+// - add a wrapper for individual values with serialization/editor custom attribute built in, such that it's name is serialized
+// - this would allow new enum members to be added anywhere within their definition _without_ the current side effect
+//   of all currently stored enum fields in the editor becoming incorrect due to change in enum member's implicit integer
+//   value, since that index is what Unity serializes by default
+//
+//
 namespace PQ.Common.Containers
 {
     /*

--- a/Assets/Code/Game/Entities/CharacterAnimation.cs
+++ b/Assets/Code/Game/Entities/CharacterAnimation.cs
@@ -197,7 +197,7 @@ namespace PQ.Game.Entities
         private void EnsureRegisteredAndEditorParamsAreAnExistMatch()
         {
             IReadOnlyList<string> expected = _animationParams.Values;
-            IReadOnlyList<string> actual   = (IReadOnlyList<string>)_animator.parameters.Select(param => param.name);
+            IReadOnlyList<string> actual   = _animator.parameters.Select(param => param.name).ToArray();
             for (int i = 0; i < expected.Count; i++)
             {
                 if (i >= actual.Count || expected[i] != actual[i])

--- a/Assets/Code/Game/Entities/Penguin/Components/PenguinAnimation.cs
+++ b/Assets/Code/Game/Entities/Penguin/Components/PenguinAnimation.cs
@@ -3,7 +3,7 @@
 
 namespace PQ.Game.Entities.Penguin
 {
-    public class PenguinAnimation : CharacterAnimation<PenguinAnimationEventId>
+    public class PenguinAnimation : CharacterAnimation<PenguinAnimationEventId, PenguinAnimationParamId>
     {
         protected override void OnInitialize()
         {

--- a/Assets/Code/Game/Entities/Penguin/Components/PenguinAnimationParamId.cs
+++ b/Assets/Code/Game/Entities/Penguin/Components/PenguinAnimationParamId.cs
@@ -2,16 +2,17 @@
 
 namespace PQ.Game.Entities.Penguin
 {
-    // currently, each id must correspond _exactly_ - order/name/count - to animator parameter (in future we will sync dynamically)
+    // currently, each id must correspond _exactly_ - order/name/count -
+    // to animator parameter (in future we will sync dynamically)
     public enum PenguinAnimationParamId
     {
         LocomotionIntensity,
         SlopeIntensity,
         IsGrounded,
-        TriggerLieDown,
-        TriggerStandUp,
-        TriggerJumpUp,
-        TriggerFire,
-        TriggerUse,
+        LieDown,
+        StandUp,
+        JumpUp,
+        Fire,
+        Use,
     }
 }

--- a/Assets/Code/Game/Entities/Penguin/Components/PenguinAnimationParamId.cs
+++ b/Assets/Code/Game/Entities/Penguin/Components/PenguinAnimationParamId.cs
@@ -1,11 +1,8 @@
-﻿using PQ.Common.Containers;
-
+﻿
 
 namespace PQ.Game.Entities.Penguin
 {
-    // note - until (and if) we add custom serializer hooks to get these stored via their string values, instead of ints,
-    //        then preferably we should add to the end to avoid all references from being renamed
-    //        ..but if it's not exposed in the editor, it's fine.
+    // currently, each id must correspond _exactly_ - order/name/count - to animator parameter (in future we will sync dynamically)
     public enum PenguinAnimationParamId
     {
         LocomotionIntensity,
@@ -16,30 +13,5 @@ namespace PQ.Game.Entities.Penguin
         TriggerJumpUp,
         TriggerFire,
         TriggerUse,
-    }
-
-
-    /*
-    Reminder: These parameters _must_ match the names in mecanim.
-    Unfortunately there is no easy way to generate the parameter names,
-    so just be careful to make sure that they match the parameters listed in the Unity Animator.
-
-    todo: try adding params like done in this doc example: https://docs.unity3d.com/ScriptReference/Animations.AnimatorController.html
-          eg controller.AddParameter("Fire", AnimatorControllerParameterType.Trigger);
-
-          doing this will entail some custom editor scripting, possible locking on animator values, and so forth.
-          
-    */
-    // todo: look into validation of the param names with the animator using above enums
-    public static class PenguinAnimationParamNames
-    {
-        public static readonly string paramLocomotion = "LocomotionIntensity";
-        public static readonly string paramSlope      = "SlopeIntensity";
-        public static readonly string paramIsGrounded = "IsGrounded";
-        public static readonly string paramLie        = "LieDown";
-        public static readonly string paramStand      = "StandUp";
-        public static readonly string paramJump       = "JumpUp";
-        public static readonly string paramFire       = "Fire";
-        public static readonly string paramUse        = "Use";
     }
 }

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateLyingDown.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateLyingDown.cs
@@ -17,7 +17,7 @@ namespace PQ.Game.Entities.Penguin
 
         protected override void OnEnter()
         {
-            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamNames.paramLie);
+            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.TriggerLieDown);
         }
 
         protected override void OnExit()

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateLyingDown.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateLyingDown.cs
@@ -17,7 +17,7 @@ namespace PQ.Game.Entities.Penguin
 
         protected override void OnEnter()
         {
-            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.TriggerLieDown);
+            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.LieDown);
         }
 
         protected override void OnExit()

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateMidair.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateMidair.cs
@@ -15,7 +15,7 @@ namespace PQ.Game.Entities.Penguin
 
         protected override void OnEnter()
         {
-            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.TriggerJumpUp);
+            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.JumpUp);
         }
 
         protected override void OnExit()

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateMidair.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateMidair.cs
@@ -15,7 +15,7 @@ namespace PQ.Game.Entities.Penguin
 
         protected override void OnEnter()
         {
-            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamNames.paramJump);
+            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.TriggerJumpUp);
         }
 
         protected override void OnExit()
@@ -26,7 +26,7 @@ namespace PQ.Game.Entities.Penguin
 
         private void HandleGroundContactChanged(bool isGrounded)
         {
-            Blob.Animation.SetBool(PenguinAnimationParamNames.paramIsGrounded, isGrounded);
+            Blob.Animation.SetBool(PenguinAnimationParamId.IsGrounded, isGrounded);
             if (isGrounded)
             {
                 base.SignalMoveToLastState();

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnBelly.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnBelly.cs
@@ -28,7 +28,7 @@ namespace PQ.Game.Entities.Penguin
         protected override void OnExit()
         {
             _locomotionBlend = 0.0f;
-            Blob.Animation.SetFloat(PenguinAnimationParamNames.paramLocomotion, _locomotionBlend);
+            Blob.Animation.SetFloat(PenguinAnimationParamId.LocomotionIntensity, _locomotionBlend);
         }
 
         protected override void OnUpdate()
@@ -40,7 +40,7 @@ namespace PQ.Game.Entities.Penguin
         // todo: look into putting the ground check animation update somewhere else more reusable, like a penguin base state
         private void HandleGroundContactChanged(bool isGrounded)
         {
-            Blob.Animation.SetBool(PenguinAnimationParamNames.paramIsGrounded, isGrounded);
+            Blob.Animation.SetBool(PenguinAnimationParamId.IsGrounded, isGrounded);
         }
 
         private void HandleStandUpInputReceived()
@@ -81,7 +81,7 @@ namespace PQ.Game.Entities.Penguin
                 //MoveHorizontal(penguinRigidbody, _xMotionIntensity * _maxInputSpeed, Time.deltaTime);
             }
 
-            Blob.Animation.SetFloat(PenguinAnimationParamNames.paramLocomotion, _locomotionBlend);
+            Blob.Animation.SetFloat(PenguinAnimationParamId.LocomotionIntensity, _locomotionBlend);
         }
     }
 }

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnFeet.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnFeet.cs
@@ -59,7 +59,7 @@ namespace PQ.Game.Entities.Penguin
 
         private void HandleJumpInputReceived()
         {
-            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.TriggerJumpUp);
+            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.JumpUp);
         }
 
         private void HandleJumpLiftOff()

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnFeet.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnFeet.cs
@@ -32,7 +32,7 @@ namespace PQ.Game.Entities.Penguin
         {
             _locomotionBlend = 0.0f;
             _horizontalInput = new(HorizontalInput.Type.None);
-            Blob.Animation.SetFloat(PenguinAnimationParamNames.paramLocomotion, _locomotionBlend);
+            Blob.Animation.SetFloat(PenguinAnimationParamId.LocomotionIntensity, _locomotionBlend);
         }
 
         protected override void OnUpdate()
@@ -49,7 +49,7 @@ namespace PQ.Game.Entities.Penguin
 
         private void HandleGroundContactChanged(bool isGrounded)
         {
-            Blob.Animation.SetBool(PenguinAnimationParamNames.paramIsGrounded, isGrounded);
+            Blob.Animation.SetBool(PenguinAnimationParamId.IsGrounded, isGrounded);
             if (!isGrounded)
             {
                 base.SignalMoveToNextState(PenguinStateId.Midair);
@@ -59,7 +59,7 @@ namespace PQ.Game.Entities.Penguin
 
         private void HandleJumpInputReceived()
         {
-            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamNames.paramJump);
+            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.TriggerJumpUp);
         }
 
         private void HandleJumpLiftOff()
@@ -101,7 +101,7 @@ namespace PQ.Game.Entities.Penguin
                 //MoveHorizontal(penguinRigidbody, _xMotionIntensity * _maxInputSpeed, Time.deltaTime);
             }
 
-            Blob.Animation.SetFloat(PenguinAnimationParamNames.paramLocomotion, _locomotionBlend);
+            Blob.Animation.SetFloat(PenguinAnimationParamId.LocomotionIntensity, _locomotionBlend);
         }
     }
 }

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateStandingUp.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateStandingUp.cs
@@ -16,7 +16,7 @@ namespace PQ.Game.Entities.Penguin
 
         protected override void OnEnter()
         {
-            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.TriggerStandUp);
+            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.StandUp);
         }
 
         protected override void OnExit()

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateStandingUp.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateStandingUp.cs
@@ -16,7 +16,7 @@ namespace PQ.Game.Entities.Penguin
 
         protected override void OnEnter()
         {
-            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamNames.paramStand);
+            Blob.Animation.AddTriggerToQueue(PenguinAnimationParamId.TriggerStandUp);
         }
 
         protected override void OnExit()


### PR DESCRIPTION
Reworks things to use param IDs fully for animations in a way similar to fsm states.