### PR TITLE
Pill: Flesh out simple linear kinematic model for climbing slopes

### DIFF
--- a/Assets/Sandbox/Minimal/CastResult.cs
+++ b/Assets/Sandbox/Minimal/CastResult.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics.Contracts;
+using UnityEngine;
+
+
+namespace PQ.TestScenes.Minimal
+{
+    /* Result info of a single ray-surface intersection, with extra convenience methods over built in cast result struct. */
+    public struct CastResult
+    {
+        public readonly Rigidbody2D rigidBody;
+        public readonly Vector2     normal;
+        public readonly float       distance;
+
+        public override string ToString() =>
+            $"{GetType().Name}:{{" +
+                $"normal:{normal}," +
+                $"distance:{distance}," +
+                $"rigidBody:{rigidBody?.ToString() ?? "<None>"}}}";
+
+
+        public CastResult(Rigidbody2D rigidBody, Vector2 normal, float distance)
+        {
+            this.rigidBody = rigidBody;
+            this.normal    = normal;
+            this.distance  = distance;
+        }
+
+        [Pure]
+        public bool HitInRange(float min, float max)
+        {
+            return rigidBody != null && distance >= min && distance <= max;
+        }
+
+        public static implicit operator bool(CastResult hit)
+        {
+            return hit.rigidBody != null;
+        }
+    }
+}

--- a/Assets/Sandbox/Minimal/CastResult.cs.meta
+++ b/Assets/Sandbox/Minimal/CastResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b7035347e5d5304394cb23f5202d52d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sandbox/Minimal/Minimal.unity
+++ b/Assets/Sandbox/Minimal/Minimal.unity
@@ -564,7 +564,7 @@ PrefabInstance:
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 17.5
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
@@ -736,7 +736,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
       propertyPath: _horizontalSpeed
-      value: 50
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 1438510890908960805, guid: dd5a67d8713f6b749bec88fb637937fe,
         type: 3}
@@ -751,12 +751,12 @@ PrefabInstance:
     - target: {fileID: 1438510890908960807, guid: dd5a67d8713f6b749bec88fb637937fe,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 600
+      value: -350
       objectReference: {fileID: 0}
     - target: {fileID: 1438510890908960807, guid: dd5a67d8713f6b749bec88fb637937fe,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 40
+      value: -130
       objectReference: {fileID: 0}
     - target: {fileID: 1438510890908960807, guid: dd5a67d8713f6b749bec88fb637937fe,
         type: 3}
@@ -1427,17 +1427,22 @@ PrefabInstance:
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 100
+      value: 99.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 9.5575
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -250
+      value: -252.05
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -30
+      value: -53.1
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
@@ -1447,22 +1452,22 @@ PrefabInstance:
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.9961947
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0.08715578
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
@@ -1477,7 +1482,7 @@ PrefabInstance:
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060367, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
@@ -1596,12 +1601,12 @@ PrefabInstance:
     - target: {fileID: 1543372937319591288, guid: 0d871c89d4c3229449c3ffe9396b216f,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 620
+      value: -330
       objectReference: {fileID: 0}
     - target: {fileID: 1543372937319591288, guid: 0d871c89d4c3229449c3ffe9396b216f,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 55
+      value: -115
       objectReference: {fileID: 0}
     - target: {fileID: 1543372937319591288, guid: 0d871c89d4c3229449c3ffe9396b216f,
         type: 3}

--- a/Assets/Sandbox/Minimal/Minimal.unity
+++ b/Assets/Sandbox/Minimal/Minimal.unity
@@ -732,11 +732,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
       propertyPath: _contactOffset
-      value: 5
+      value: 2.5
       objectReference: {fileID: 0}
     - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
       propertyPath: _horizontalSpeed
-      value: 200
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 1438510890908960805, guid: dd5a67d8713f6b749bec88fb637937fe,
         type: 3}
@@ -751,7 +751,7 @@ PrefabInstance:
     - target: {fileID: 1438510890908960807, guid: dd5a67d8713f6b749bec88fb637937fe,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 450
+      value: 600
       objectReference: {fileID: 0}
     - target: {fileID: 1438510890908960807, guid: dd5a67d8713f6b749bec88fb637937fe,
         type: 3}
@@ -1596,7 +1596,7 @@ PrefabInstance:
     - target: {fileID: 1543372937319591288, guid: 0d871c89d4c3229449c3ffe9396b216f,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 470
+      value: 620
       objectReference: {fileID: 0}
     - target: {fileID: 1543372937319591288, guid: 0d871c89d4c3229449c3ffe9396b216f,
         type: 3}

--- a/Assets/Sandbox/Minimal/SimpleCharacterController2D.cs
+++ b/Assets/Sandbox/Minimal/SimpleCharacterController2D.cs
@@ -100,6 +100,30 @@ namespace PQ.TestScenes.Minimal
             body.position += direction.normalized * distance;
         }
 
+
+        /*
+        Apply bounciness/friction coefficients to hit position/normal, in proportion with the desired movement distance.
+
+
+        In other words, collision parameters for an impact point, what's the adjusted position when taking into account
+        desired delta, using a simple linear model (similar to what Unity's dynamic physics material provides).
+
+        Note that bounciness is from 0 (no bounciness) to 1 (completely reflected),
+        and that friction is from -1 ('boosts' velocity) to 0 (no resistance) to 1 (max resistance).
+        */
+        private static Vector2 ResolveCollision(Vector2 desiredPosition, Vector2 hitPosition, Vector2 hitNormal, float bounciness, float friction)
+        {
+            Vector2 delta  = desiredPosition - hitPosition;
+            float remainingDistance = delta.magnitude;
+            Vector2 reflected  = Vector2.Reflect(delta, hitNormal);
+            Vector2 projection = Vector2.Dot(reflected, hitNormal) * hitNormal;
+            Vector2 tangent    = reflected - projection;
+
+            Vector2 perpendicularContribution = bounciness      * remainingDistance * projection.normalized;
+            Vector2 tangentialContribution    = (1f - friction) * remainingDistance * tangent.normalized;
+            return hitPosition + perpendicularContribution + tangentialContribution;
+        }
+
         private void SetXYOrientation(float degreesAroundXAxis, float degreesAroundYAxis)
         {
             _rigidBody.transform.localEulerAngles =

--- a/Assets/Sandbox/Minimal/SimpleCharacterController2D.cs
+++ b/Assets/Sandbox/Minimal/SimpleCharacterController2D.cs
@@ -55,7 +55,7 @@ namespace PQ.TestScenes.Minimal
         }
 
         Vector2 ICharacterController2D.Position   => _position;
-        Bounds  ICharacterController2D.Bounds     => _capsule.bounds;
+        Bounds  ICharacterController2D.Bounds     => _bounds;
         Vector2 ICharacterController2D.Forward    => _forward;
         Vector2 ICharacterController2D.Up         => _up;
         bool    ICharacterController2D.IsGrounded => _isGrounded;
@@ -100,7 +100,7 @@ namespace PQ.TestScenes.Minimal
         }
 
 
-        /* Project rigidbody forward, taking skin width and attached colliders into account, and return the closest cast hit. */
+        /* Project rigidbody forward, taking skin width and attached colliders into account, and return the closest rigidbody hit. */
         private static CastResult DetectCollision(Rigidbody2D rigidBody, Vector2 delta,
             in ContactFilter2D filter, float skinWidth, RaycastHit2D[] results)
         {

--- a/Assets/Sandbox/Minimal/SimpleCharacterController2D.cs
+++ b/Assets/Sandbox/Minimal/SimpleCharacterController2D.cs
@@ -104,24 +104,23 @@ namespace PQ.TestScenes.Minimal
         /*
         Apply bounciness/friction coefficients to hit position/normal, in proportion with the desired movement distance.
 
-
-        In other words, collision parameters for an impact point, what's the adjusted position when taking into account
-        desired delta, using a simple linear model (similar to what Unity's dynamic physics material provides).
-
-        Note that bounciness is from 0 (no bounciness) to 1 (completely reflected),
-        and that friction is from -1 ('boosts' velocity) to 0 (no resistance) to 1 (max resistance).
+        In other words, for a given collision what is the adjusted delta when taking impact angle, velocity, bounciness,
+        and friction into account (using a linear model similar to Unity's dynamic physics)?
+        
+        Note that collisions are resolved via: adjustedDelta = moveDistance * [(Sbounciness)Snormal + (1-Sfriction)Stangent]
+            * where bounciness is from 0 (no bounciness) to 1 (completely reflected)
+            * friction is from -1 ('boosts' velocity) to 0 (no resistance) to 1 (max resistance)
         */
-        private static Vector2 ResolveCollision(Vector2 desiredPosition, Vector2 hitPosition, Vector2 hitNormal, float bounciness, float friction)
+        private static Vector2 ComputeCollisionDelta(Vector2 desiredDelta, Vector2 hitNormal, float bounciness, float friction)
         {
-            Vector2 delta  = desiredPosition - hitPosition;
-            float remainingDistance = delta.magnitude;
-            Vector2 reflected  = Vector2.Reflect(delta, hitNormal);
+            float remainingDistance = desiredDelta.magnitude;
+            Vector2 reflected  = Vector2.Reflect(desiredDelta, hitNormal);
             Vector2 projection = Vector2.Dot(reflected, hitNormal) * hitNormal;
             Vector2 tangent    = reflected - projection;
 
-            Vector2 perpendicularContribution = bounciness      * remainingDistance * projection.normalized;
-            Vector2 tangentialContribution    = (1f - friction) * remainingDistance * tangent.normalized;
-            return hitPosition + perpendicularContribution + tangentialContribution;
+            Vector2 perpendicularContribution = (bounciness      * remainingDistance) * projection.normalized;
+            Vector2 tangentialContribution    = ((1f - friction) * remainingDistance) * tangent.normalized;
+            return perpendicularContribution + tangentialContribution;
         }
 
         private void SetXYOrientation(float degreesAroundXAxis, float degreesAroundYAxis)


### PR DESCRIPTION
# Pill: Flesh out simple linear kinematic model for climbing slopes

Continuing my collide-and-slide movement model for the 'pill' - I break out the steps further into `CastAndMove`, `DetectCollision`, and `ComputeCollisionDelta`. The overall algorithm, in a nutshell is now basically:
```
repeatuntil target-reached or iteration-cap-exceeded:

    foreach attached-collider:
        shoot out shape casts

    foreach cast-result:
        update closest-distance

    move body along current direction by closest-found-distance
    adjust body position based on friction and bounciness for that collision
```

![climbing-linear-slope-1](https://user-images.githubusercontent.com/8084757/200131535-b5b6916c-418e-4f78-ab85-1eaa39b40e31.png)
![climbing-linear-slope-2](https://user-images.githubusercontent.com/8084757/200131544-aa44572a-dc37-496a-8b0c-30f541527f00.png)

