### PR TITLE
Slope Climbing: Bug fixes and polish

### DIFF
--- a/Assets/Sandbox/Minimal/CharacterEntity.cs
+++ b/Assets/Sandbox/Minimal/CharacterEntity.cs
@@ -31,6 +31,11 @@ namespace PQ.TestScenes.Minimal
 
         private void Awake()
         {
+            if (_settings == null)
+            {
+                throw new MissingComponentException($"Reference to settings {_settings.GetType()} not attached to {gameObject.name}");
+            }
+
             _solverParams = new Physics.SolverParams();
             SyncPropertiesFromSettings();
             _input = new GameplayInput();

--- a/Assets/Sandbox/Minimal/Minimal.unity
+++ b/Assets/Sandbox/Minimal/Minimal.unity
@@ -730,31 +730,6 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
-      propertyPath: _settings
-      value: 
-      objectReference: {fileID: 11400000, guid: e4b244f5d53039347814ddb4b7ebce2b,
-        type: 2}
-    - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
-      propertyPath: _walkSpeed
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
-      propertyPath: _contactOffset
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
-      propertyPath: _maxSlopeAngle
-      value: 70
-      objectReference: {fileID: 0}
-    - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
-      propertyPath: _horizontalSpeed
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 710134267, guid: dd5a67d8713f6b749bec88fb637937fe, type: 3}
-      propertyPath: _contactFilter.layerMask.m_Bits
-      value: 256
-      objectReference: {fileID: 0}
     - target: {fileID: 1438510890908960805, guid: dd5a67d8713f6b749bec88fb637937fe,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
@@ -126,7 +126,11 @@ namespace PQ.TestScenes.Minimal.Physics
             var closestHitNormal   = Vector2.zero;
             var closestHitDistance = delta.magnitude;
             for (int i = 0; i < _lastHitCount; i++)
-            {
+            {                
+                #if UNITY_EDITOR
+                if (DrawCastsInEditor)
+                    DrawCastResultAsLineInEditor(_castHits[i], delta, _skinWidth);
+                #endif
                 float adjustedDistance = _castHits[i].distance - _skinWidth;
                 if (adjustedDistance > 0f && adjustedDistance < closestHitDistance)
                 {
@@ -143,11 +147,6 @@ namespace PQ.TestScenes.Minimal.Physics
             }
             hitDistance = closestHitDistance;
             hitNormal   = closestHitNormal;
-            
-            #if UNITY_EDITOR
-            if (DrawCastsInEditor)
-                DrawLastSuccessfulCasts(delta, new Vector2(_skinWidth, _skinWidth));
-            #endif
             return true;
         }
         
@@ -175,19 +174,22 @@ namespace PQ.TestScenes.Minimal.Physics
             GizmoExtensions.DrawArrow(from: center, to: center + yAxis, color: Color.green);
         }
 
-        private void DrawLastSuccessfulCasts(Vector2 castDelta, Vector2 castOffset)
+        private static void DrawCastResultAsLineInEditor(RaycastHit2D hit, Vector2 delta, float offset)
         {
-            float duration = Time.fixedDeltaTime;
-            for (int i = 0; i < _lastHitCount; i++)
+            if (!hit)
             {
-                var origin = _castHits[i].point - castDelta;
-                var start  = _castHits[i].point + castOffset;
-                var end    = _castHits[i].point;
-
-                Debug.DrawLine(start,  end,    Color.red,     duration);
-                Debug.DrawLine(start,  origin, Color.magenta, duration);
-                Debug.DrawLine(origin, end,    Color.green,   duration);
+                // unfortunately we can't reliably find the origin of the cast
+                // if there was no hit (as far as I'm aware), so nothing to draw
+                return;
             }
+
+            float duration = Time.fixedDeltaTime;
+            var origin = hit.point - delta;
+            var start  = origin    + (offset * delta.normalized);
+            var end    = hit.point;
+            Debug.DrawLine(start,  end,    Color.red,     duration);
+            Debug.DrawLine(start,  origin, Color.magenta, duration);
+            Debug.DrawLine(origin, end,    Color.green,   duration);
         }
         #endif
     }

--- a/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
@@ -182,14 +182,17 @@ namespace PQ.TestScenes.Minimal.Physics
                 // if there was no hit (as far as I'm aware), so nothing to draw
                 return;
             }
+            
+            var duration  = Time.fixedDeltaTime;
+            var direction = delta.normalized;
+            var start    = hit.point - hit.distance * direction;
+            var origin   = hit.point - (hit.distance - offset) * direction;
+            var hitPoint = hit.point;
+            var end      = hit.point + (1f - hit.fraction) * (delta.magnitude + offset) * direction;
 
-            float duration = Time.fixedDeltaTime;
-            var origin = hit.point - delta;
-            var start  = origin    + (offset * delta.normalized);
-            var end    = hit.point;
-            Debug.DrawLine(start,  end,    Color.red,     duration);
-            Debug.DrawLine(start,  origin, Color.magenta, duration);
-            Debug.DrawLine(origin, end,    Color.green,   duration);
+            Debug.DrawLine(start,    origin,   Color.magenta, duration);
+            Debug.DrawLine(origin,   hitPoint, Color.green,   duration);
+            Debug.DrawLine(hitPoint, end,      Color.red,     duration);
         }
         #endif
     }

--- a/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
@@ -125,7 +125,7 @@ namespace PQ.TestScenes.Minimal.Physics
 
             var closestHitNormal   = Vector2.zero;
             var closestHitDistance = delta.magnitude;
-            for (int i = 0; i < _castHits.Length; i++)
+            for (int i = 0; i < _lastHitCount; i++)
             {
                 float adjustedDistance = _castHits[i].distance - _skinWidth;
                 if (adjustedDistance > 0f && adjustedDistance < closestHitDistance)

--- a/Assets/Sandbox/Minimal/PlayerPill.prefab
+++ b/Assets/Sandbox/Minimal/PlayerPill.prefab
@@ -34,7 +34,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &1438510890908960806
 SpriteRenderer:
@@ -160,4 +160,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 43f90782d04554f46ace8021df1aab4a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _settings: {fileID: 0}
+  _settings: {fileID: 11400000, guid: e4b244f5d53039347814ddb4b7ebce2b, type: 2}


### PR DESCRIPTION
# Slope Climbing: Bug fixes and polish
Adds some safety checks for settings, brings prefabs to parity with scene objects, fixes some collision overlap issues, and properly draws ray casts made from kinematic body.