### PR TITLE
Slope Climbing: Smoothen out movement by explicitly adjusting extrapolated move distance for skin width

### DIFF
--- a/Assets/Sandbox/Minimal/Minimal.unity
+++ b/Assets/Sandbox/Minimal/Minimal.unity
@@ -989,12 +989,12 @@ PrefabInstance:
     - target: {fileID: -4625578252248657165, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_Size.x
-      value: 2.2656121
+      value: 1.7523434
       objectReference: {fileID: 0}
     - target: {fileID: -4625578252248657165, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_Offset.x
-      value: 0.14719388
+      value: -0.10944024
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
@@ -1014,12 +1014,12 @@ PrefabInstance:
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 691.0217
+      value: 691.05
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 135.5377
+      value: 135.5
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
@@ -1349,6 +1349,16 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 1393920134}
     m_Modifications:
+    - target: {fileID: -4625578252248657165, guid: 4f76ad3638e7f4542a508d222860ff1c,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 2.957446
+      objectReference: {fileID: 0}
+    - target: {fileID: -4625578252248657165, guid: 4f76ad3638e7f4542a508d222860ff1c,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: -0.19872314
+      objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_RootOrder
@@ -1361,13 +1371,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
+      propertyPath: m_LocalScale.y
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
+        type: 3}
       propertyPath: m_LocalPosition.x
-      value: 780
+      value: 780.2
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 143.25
+      value: 143.2
       objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}

--- a/Assets/Sandbox/Minimal/Minimal.unity
+++ b/Assets/Sandbox/Minimal/Minimal.unity
@@ -807,6 +807,16 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 1393920134}
     m_Modifications:
+    - target: {fileID: -4625578252248657165, guid: 4f76ad3638e7f4542a508d222860ff1c,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 2.435226
+      objectReference: {fileID: 0}
+    - target: {fileID: -4625578252248657165, guid: 4f76ad3638e7f4542a508d222860ff1c,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: -0.06238699
+      objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_RootOrder
@@ -976,6 +986,16 @@ PrefabInstance:
     serializedVersion: 2
     m_TransformParent: {fileID: 1393920134}
     m_Modifications:
+    - target: {fileID: -4625578252248657165, guid: 4f76ad3638e7f4542a508d222860ff1c,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 2.2656121
+      objectReference: {fileID: 0}
+    - target: {fileID: -4625578252248657165, guid: 4f76ad3638e7f4542a508d222860ff1c,
+        type: 3}
+      propertyPath: m_Offset.x
+      value: 0.14719388
+      objectReference: {fileID: 0}
     - target: {fileID: 3204818302733060353, guid: 4f76ad3638e7f4542a508d222860ff1c,
         type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Sandbox/Minimal/Physics/CollideAndSlideSolver2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/CollideAndSlideSolver2D.cs
@@ -76,6 +76,13 @@ namespace PQ.TestScenes.Minimal.Physics
                 // move a single linear step along our delta until the detected collision
                 ExtrapolateLinearStep(currentDelta, out Vector2 step, out RaycastHit2D hit);
 
+                if (!hit)
+                {
+                    // nothing blocking our path, move straight ahead, and don't worry about energy loss (for now)
+                    _body.MoveBy(step);
+                    break;
+                }
+
                 // unless there's an overly steep slope, move a linear step with properties taken into account
                 if (Vector2.Angle(Vector2.up, hit.normal) <= _params.MaxSlopeAngle)
                 {
@@ -108,8 +115,9 @@ namespace PQ.TestScenes.Minimal.Physics
                 // only if there's an overly steep slope, do we want to take action (eg sliding down)
                 if (Vector2.Angle(Vector2.up, hit.normal) > _params.MaxSlopeAngle)
                 {
-                    currentDelta += ComputeCollisionDelta(currentDelta, hit.normal);
+                    step += ComputeCollisionDelta(currentDelta, hit.normal);
                 }
+
                 _body.MoveBy(step);
             }
 

--- a/Assets/Sandbox/Minimal/Physics/CollideAndSlideSolver2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/CollideAndSlideSolver2D.cs
@@ -72,20 +72,24 @@ namespace PQ.TestScenes.Minimal.Physics
             Vector2 currentDelta = targetDelta;
             while (iteration < _params.MaxIterations && !HasReachedTarget(currentDelta))
             {
-                if (!_body.FindClosestCollisionAlongDelta(currentDelta, _params.LayerMask, out var hit))
+                if (!_body.FindClosestCollisionAlongDelta(currentDelta, _params.LayerMask, out RaycastHit2D hit))
                 {
                     // nothing blocking our path, move straight ahead, and don't worry about energy loss (for now)
                     _body.MoveBy(currentDelta);
                     break;
                 }
 
+                // move a single linear step along our delta until the detected collision
+                if (hit.distance > _params.ContactOffset)
+                {
+                    currentDelta = hit.distance * currentDelta.normalized;
+                }
+
                 // unless there's an overly steep slope, move a linear step with properties taken into account
                 float slopeAngle = Vector2.Angle(_body.Up, hit.normal);
                 if (slopeAngle <= _params.MaxSlopeAngle)
                 {
-                    // move a single linear step along our delta until the detected collision
-                    currentDelta = hit.distance * currentDelta.normalized;
-                    currentDelta = ComputeCollisionDelta(currentDelta, hit.normal, _params.Bounciness, _params.Friction);
+                    currentDelta += ComputeCollisionDelta(currentDelta, hit.normal, _params.Bounciness, _params.Friction);
                 }
                 else
                 {
@@ -104,20 +108,24 @@ namespace PQ.TestScenes.Minimal.Physics
             Vector2 currentDelta = targetDelta;
             while (iteration < _params.MaxIterations && !HasReachedTarget(currentDelta))
             {
-                if (!_body.FindClosestCollisionAlongDelta(currentDelta, _params.LayerMask, out var hit))
+                if (!_body.FindClosestCollisionAlongDelta(currentDelta, _params.LayerMask, out RaycastHit2D hit))
                 {
                     // nothing blocking our path, move straight ahead, and don't worry about energy loss (for now)
                     _body.MoveBy(currentDelta);
                     break;
                 }
-                
+
+                // move a single linear step along our delta until the detected collision
+                if (hit.distance > _params.ContactOffset)
+                {
+                    currentDelta = hit.distance * currentDelta.normalized;
+                }
+
                 // only if there's an overly steep slope, do we want to take action (eg sliding down)
                 float slopeAngle = Vector2.Angle(Vector2.up, hit.normal);
                 if (slopeAngle > _params.MaxSlopeAngle)
                 {
-                    // move a single linear step along our delta until the detected collision
-                    currentDelta = hit.distance * currentDelta.normalized;
-                    currentDelta = ComputeCollisionDelta(currentDelta, hit.normal, _params.Bounciness, _params.Friction);
+                    currentDelta += ComputeCollisionDelta(currentDelta, hit.normal, _params.Bounciness, _params.Friction);
                 }
 
                 _body.MoveBy(currentDelta);

--- a/Assets/Sandbox/Minimal/Physics/CollideAndSlideSolver2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/CollideAndSlideSolver2D.cs
@@ -79,7 +79,7 @@ namespace PQ.TestScenes.Minimal.Physics
                 // unless there's an overly steep slope, move a linear step with properties taken into account
                 if (Vector2.Angle(Vector2.up, hit.normal) <= _params.MaxSlopeAngle)
                 {
-                    step += ComputeCollisionDelta(currentDelta, hit.normal, _params.Bounciness, _params.Friction);
+                    step += ComputeCollisionDelta(currentDelta, hit.normal);
                 }
 
                 _body.MoveBy(step);
@@ -108,18 +108,16 @@ namespace PQ.TestScenes.Minimal.Physics
                 // only if there's an overly steep slope, do we want to take action (eg sliding down)
                 if (Vector2.Angle(Vector2.up, hit.normal) > _params.MaxSlopeAngle)
                 {
-                    currentDelta += ComputeCollisionDelta(currentDelta, hit.normal, _params.Bounciness, _params.Friction);
+                    currentDelta += ComputeCollisionDelta(currentDelta, hit.normal);
                 }
+                _body.MoveBy(step);
             }
 
             _collisions |= flags;
         }
 
 
-        /*
-        Given ray cast results, how far (if at all) can we move until that collision?
-        If no collision, return false.
-        */
+        /* How far can we move unobstructed along given vector without being hit? */
         private void ExtrapolateLinearStep(Vector2 desiredDelta, out Vector2 step, out RaycastHit2D hit)
         {
             if (!_body.CastAAB(desiredDelta, _params.LayerMask, out ReadOnlySpan<RaycastHit2D> hits))
@@ -159,15 +157,15 @@ namespace PQ.TestScenes.Minimal.Physics
             * where bounciness is from 0 (no bounciness) to 1 (completely reflected)
             * friction is from -1 ('boosts' velocity) to 0 (no resistance) to 1 (max resistance)
         */
-        private static Vector2 ComputeCollisionDelta(Vector2 desiredDelta, Vector2 hitNormal, float bounciness, float friction)
+        private Vector2 ComputeCollisionDelta(Vector2 desiredDelta, Vector2 hitNormal)
         {
             float remainingDistance = desiredDelta.magnitude;
             Vector2 reflected  = Vector2.Reflect(desiredDelta, hitNormal);
             Vector2 projection = Vector2.Dot(reflected, hitNormal) * hitNormal;
             Vector2 tangent    = reflected - projection;
 
-            Vector2 perpendicularContribution = (bounciness      * remainingDistance) * projection.normalized;
-            Vector2 tangentialContribution    = ((1f - friction) * remainingDistance) * tangent.normalized;
+            Vector2 perpendicularContribution = (_params.Bounciness      * remainingDistance) * projection.normalized;
+            Vector2 tangentialContribution    = ((1f - _params.Friction) * remainingDistance) * tangent.normalized;
             return perpendicularContribution + tangentialContribution;
         }
     }

--- a/Assets/Sandbox/Minimal/Physics/CollideAndSlideSolver2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/CollideAndSlideSolver2D.cs
@@ -71,6 +71,7 @@ namespace PQ.TestScenes.Minimal.Physics
         {
             int iteration = 0;
             Vector2 currentDelta = targetDelta;
+            CollisionFlags2D flags = CollisionFlags2D.None;
             while (iteration < _params.MaxIterations && !HasReachedTarget(currentDelta))
             {
                 if (!_body.CastAAB(currentDelta, _params.LayerMask, out ReadOnlySpan<RaycastHit2D> hits))
@@ -102,6 +103,8 @@ namespace PQ.TestScenes.Minimal.Physics
                 _body.MoveBy(currentDelta);
                 iteration++;
             }
+
+            _collisions |= flags;
         }
 
         /* Iteratively move body along surface one linear step at a time until target reached, or iteration cap exceeded. */
@@ -109,6 +112,7 @@ namespace PQ.TestScenes.Minimal.Physics
         {
             int iteration = 0;
             Vector2 currentDelta = targetDelta;
+            CollisionFlags2D flags = CollisionFlags2D.None;
             while (iteration < _params.MaxIterations && !HasReachedTarget(currentDelta))
             {
                 if (!_body.CastAAB(currentDelta, _params.LayerMask, out ReadOnlySpan<RaycastHit2D> hits))
@@ -136,6 +140,8 @@ namespace PQ.TestScenes.Minimal.Physics
                 _body.MoveBy(currentDelta);
                 iteration++;
             }
+
+            _collisions |= flags;
         }
 
         /*

--- a/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
@@ -37,7 +37,7 @@ namespace PQ.TestScenes.Minimal.Physics
 
         public bool DrawCastsInEditor { get; set; } = true;
 
-        public Bounds BoundsWithSkinWidth
+        public Bounds BoundsOuter
         {
             get
             {
@@ -150,7 +150,26 @@ namespace PQ.TestScenes.Minimal.Physics
             }
         }
 
-        
+        /* What's the delta between the AAB and the expanded AAB (with skin width) from center in given direction? */
+        public Vector2 ComputeContactOffset(Vector2 direction)
+        {
+            if (Mathf.Approximately(_skinWidth, 0f))
+            {
+                return Vector2.zero;
+            }
+
+            Vector2 center    = Vector2.zero;
+            Vector2 size      = new(_boxCollider.bounds.size.x, _boxCollider.bounds.size.y);
+            Vector2 maxOffset = new(_skinWidth, _skinWidth);
+
+            Ray    ray   = new(center, direction);
+            Bounds inner = new(center, size);
+            Bounds outer = new(center, size + maxOffset);
+            inner.IntersectRay(ray, out float distanceToInner);
+            outer.IntersectRay(ray, out float distanceToOuter);
+            return (distanceToOuter - distanceToInner) * direction.normalized;
+        }
+
         /* Check each side for _any_ colliders occupying the region between AAB and the outer perimeter defined by skin width. */
         public CollisionFlags2D CheckForOverlappingContacts(in LayerMask layerMask, float maxAngle)
         {

--- a/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
+++ b/Assets/Sandbox/Minimal/Physics/KinematicBody2D.cs
@@ -196,9 +196,15 @@ namespace PQ.TestScenes.Minimal.Physics
             return true;
         }
         
-
-
+        
         #if UNITY_EDITOR
+        void OnGUI()
+        {
+            GUI.Label(new Rect(0,  0, 100, 20), "Stat1");
+            GUI.Label(new Rect(0, 20, 100, 20), "Stat2");
+            GUI.Label(new Rect(0, 40, 100, 20), "Stat3");
+        }
+
         void OnDrawGizmos()
         {
             if (!Application.IsPlaying(this) || !enabled)

--- a/Assets/Sandbox/Minimal/PillEntitySettings.asset
+++ b/Assets/Sandbox/Minimal/PillEntitySettings.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c4cfdff3a313d574e8e345f7538539da, type: 3}
   m_Name: PillEntitySettings
   m_EditorClassIdentifier: 
-  walkSpeed: 50
+  walkSpeed: 10
   jumpSpeed: 500
   jumpLengthToApex: 10
   jumpHeightToApex: 10

--- a/Assets/Sandbox/Minimal/PillEntitySettings.asset
+++ b/Assets/Sandbox/Minimal/PillEntitySettings.asset
@@ -12,11 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c4cfdff3a313d574e8e345f7538539da, type: 3}
   m_Name: PillEntitySettings
   m_EditorClassIdentifier: 
-  walkSpeed: 10
+  walkSpeed: 50
   jumpSpeed: 500
   jumpLengthToApex: 10
   jumpHeightToApex: 10
-  solverIterationsPerPhysicsUpdate: 10
+  solverIterationsPerPhysicsUpdate: 1
   collisionBounciness: 0
   collisionFriction: 0
   maxAscendableSlopeAngle: 70

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -18,7 +18,7 @@ Physics2DSettings:
   m_TimeToSleep: 0.5
   m_LinearSleepTolerance: 0.01
   m_AngularSleepTolerance: 2
-  m_DefaultContactOffset: 0.025
+  m_DefaultContactOffset: 0.05
   m_JobOptions:
     serializedVersion: 2
     useMultithreading: 0


### PR DESCRIPTION
Smoothen out movement by explicitly adjusting extrapolated move distance for skin width, as part of a solver simplification effort.