### PR TITLE
Fix follow subject assignment for cinemachine camera

### DIFF
--- a/Assets/Code/Game/GameController.cs
+++ b/Assets/Code/Game/GameController.cs
@@ -3,6 +3,7 @@ using PQ.Common.Extensions;
 using PQ.Game.Entities;
 using PQ.Game.Sound;
 using PQ.Game.Input;
+using PQ.Game.Camera;
 
 
 // todo: replace config settings with scriptable objects

--- a/Assets/Prefabs/Cameras.prefab
+++ b/Assets/Prefabs/Cameras.prefab
@@ -497,7 +497,7 @@ Transform:
   - {fileID: 4401863855712604966}
   - {fileID: 4401863855148388952}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3852360466960447003
 MonoBehaviour:
@@ -511,9 +511,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd10308f50df4c64285d0ef9c5bfe12c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _followSubject: {fileID: 0}
-  _mainCam: {fileID: 0}
-  _vCams: []
+  _mainCamera: {fileID: 4401863854545358132}
+  _brain: {fileID: 4401863854545358129}
+  _virtualCameras:
+  - {fileID: 4401863856316295328}
+  - {fileID: 4401863855724230868}
+  - {fileID: 8436310291255371280}
 --- !u!1 &4401863855712604967
 GameObject:
   m_ObjectHideFlags: 0
@@ -670,7 +673,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4401863855930811704}
   - component: {fileID: 4401863855930811706}
-  - component: {fileID: 4401863855930811707}
+  - component: {fileID: 6793210330684704137}
   m_Layer: 0
   m_Name: cm
   m_TagString: Untagged
@@ -705,7 +708,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac0b09e7857660247b1477e93731de29, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &4401863855930811707
+--- !u!114 &6793210330684704137
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -718,18 +721,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_TrackedObjectOffset: {x: 0, y: 0, z: 0}
-  m_LookaheadTime: 0.2
-  m_LookaheadSmoothing: 10
-  m_LookaheadIgnoreY: 1
+  m_LookaheadTime: 0
+  m_LookaheadSmoothing: 0
+  m_LookaheadIgnoreY: 0
   m_XDamping: 1
   m_YDamping: 1
   m_ZDamping: 1
   m_TargetMovementOnly: 1
   m_ScreenX: 0.5
-  m_ScreenY: 0.9
+  m_ScreenY: 0.5
   m_CameraDistance: 10
-  m_DeadZoneWidth: 0.2
-  m_DeadZoneHeight: 0.1
+  m_DeadZoneWidth: 0
+  m_DeadZoneHeight: 0
   m_DeadZoneDepth: 0
   m_UnlimitedSoftZone: 0
   m_SoftZoneWidth: 0.8
@@ -738,7 +741,7 @@ MonoBehaviour:
   m_BiasY: 0
   m_CenterOnActivate: 1
   m_GroupFramingMode: 2
-  m_AdjustmentMode: 2
+  m_AdjustmentMode: 0
   m_GroupFramingSize: 0.8
   m_MaxDollyIn: 5000
   m_MaxDollyOut: 5000

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -123,17 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!114 &57977307 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4401863855724230868, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-  m_PrefabInstance: {fileID: 357019674}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &68320533
 GameObject:
   m_ObjectHideFlags: 0
@@ -208,30 +197,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 265413467}
     m_Modifications:
-    - target: {fileID: 3852360466960447003, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-      propertyPath: _mainCam
-      value: 
-      objectReference: {fileID: 727460125}
-    - target: {fileID: 3852360466960447003, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-      propertyPath: _followSubject
-      value: 
-      objectReference: {fileID: 683524907}
-    - target: {fileID: 3852360466960447003, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-      propertyPath: _vCams.Array.size
-      value: 3
+    - target: {fileID: 4401863854545358135, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.7400007
       objectReference: {fileID: 0}
-    - target: {fileID: 3852360466960447003, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-      propertyPath: _vCams.Array.data[0]
-      value: 
-      objectReference: {fileID: 2064921955}
-    - target: {fileID: 3852360466960447003, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-      propertyPath: _vCams.Array.data[1]
-      value: 
-      objectReference: {fileID: 57977307}
-    - target: {fileID: 3852360466960447003, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-      propertyPath: _vCams.Array.data[2]
-      value: 
-      objectReference: {fileID: 560826194}
     - target: {fileID: 4401863855381985666, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
       propertyPath: m_RootOrder
       value: 0
@@ -391,17 +360,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ee58eee13cf475e4591f0a454fc6cf81, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &560826194 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8436310291255371280, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-  m_PrefabInstance: {fileID: 357019674}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &594763467
@@ -645,16 +603,6 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 683524891}
   m_Enabled: 1
---- !u!4 &683524907 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 99392607343190492, guid: ff13ec81cbe8014418b88c5e68427ff6, type: 3}
-  m_PrefabInstance: {fileID: 609119320}
-  m_PrefabAsset: {fileID: 0}
---- !u!20 &727460125 stripped
-Camera:
-  m_CorrespondingSourceObject: {fileID: 4401863854545358132, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-  m_PrefabInstance: {fileID: 357019674}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &755271233
 GameObject:
   m_ObjectHideFlags: 0
@@ -1024,14 +972,3 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _settings: {fileID: 11400000, guid: 69a29b76217678a48a24db8be605b111, type: 2}
---- !u!114 &2064921955 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4401863856316295328, guid: 24b234cac1a780b47bc77f81eb993d3e, type: 3}
-  m_PrefabInstance: {fileID: 357019674}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 


### PR DESCRIPTION
Configure cinemachine and camera controller scripts such that fields are enforced at game start but camera is not updated when game isn't actively playing - as a fix for follow not working properly.