### PR TITLE
Clean up collision handling for body/mover

### DIFF
--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -1,30 +1,24 @@
+using System;
 using UnityEngine;
 
 
 namespace PQ.TestScenes.Box
 {
-    public struct Hit
-    {
-        public Vector2    Point;     // position of intersection
-        public Vector2    Normal;    // surface normal of hit
-        public float      Distance;  // distance between edge of collider and intersection point
-        public Collider2D Collider;  // collider hit
-        public float      Buffer;    // offset distance
-        public Vector2    Centroid;  // center of the collider that performed the cast
-    }
     public class Body : MonoBehaviour
     {
         [SerializeField] private Rigidbody2D   _rigidBody;
         [SerializeField] private BoxCollider2D _boxCollider;
 
         [SerializeField] private LayerMask _layerMask = default;
-        [SerializeField] [Range(0, 1)]   private float _skinWidth = 0.025f;
         [SerializeField] [Range(1, 100)] private int _preallocatedHitBufferSize = 16;
+
+        #if UNITY_EDITOR        
+        [SerializeField] private bool _drawCastsInEditor = true;
+        #endif
 
         private bool _initialized;
         private ContactFilter2D _castFilter;
-        private RaycastHit2D[]  _rawResults;
-        private Hit[]           _hits;
+        private RaycastHit2D[]  _hitBuffer;
 
         public override string ToString() =>
             $"Mover{{" +
@@ -32,26 +26,15 @@ namespace PQ.TestScenes.Box
                 $"Depth:{Depth}," +
                 $"Forward:{Forward}," +
                 $"Up:{Up}," +
-                $"SkinWidth:{SkinWidth}," +
-                $"AAB: bounds(center:{Bounds.center}, extents:{Bounds.extents})," +
+                $"AABB: bounds(center:{Bounds.center}, extents:{Bounds.extents})," +
             $"}}";
 
         public Vector2 Position  => _rigidBody.position;
         public float   Depth     => _rigidBody.transform.position.z;
         public Bounds  Bounds    => _boxCollider.bounds;
-        public float   SkinWidth => _skinWidth;
         public Vector2 Forward   => _rigidBody.transform.right.normalized;
         public Vector2 Up        => _rigidBody.transform.up.normalized;
 
-        public Bounds BoundsOuter
-        {
-            get
-            {
-                var bounds = _boxCollider.bounds;
-                bounds.Expand(amount: 2f * _skinWidth);
-                return _boxCollider.bounds;
-            }
-        }
 
         void Awake()
         {
@@ -67,8 +50,7 @@ namespace PQ.TestScenes.Box
             _rigidBody   = rigidBody;
             _boxCollider = boxCollider;
             _castFilter  = new ContactFilter2D();
-            _rawResults  = new RaycastHit2D[_preallocatedHitBufferSize];
-            _hits        = new Hit[_preallocatedHitBufferSize];
+            _hitBuffer   = new RaycastHit2D[_preallocatedHitBufferSize];
             _castFilter.useLayerMask = true;
             _castFilter.SetLayerMask(_layerMask);
 
@@ -101,65 +83,63 @@ namespace PQ.TestScenes.Box
         {
             _rigidBody.position += delta;
         }
-
-        // assumes nonzero delta
-        public bool Cast_Closest(Vector2 delta, out Hit hit)
+        
+        /*
+        Project AABB along delta, and return ALL hits (if any).
+        
+        WARNING: Hits are intended to be used right away, as any subsequent casts will change the result.
+        */
+        public bool CastAll(Vector2 delta, out ReadOnlySpan<RaycastHit2D> hits)
         {
-            _castFilter.SetLayerMask(_layerMask);
-            int hitCount = _boxCollider.Cast(delta, _castFilter, _rawResults, delta.magnitude, ignoreSiblingColliders: true);
+            return CastAABB(delta, out hits);
+        }
+
+        /*
+        Project AABB along delta, and return CLOSEST hit (if any).
+        
+        WARNING: Hits are intended to be used right away, as any subsequent casts will change the result.
+        */
+        public bool CastClosest(Vector2 delta, out RaycastHit2D hit)
+        {
+            if (!CastAABB(delta, out ReadOnlySpan<RaycastHit2D> hits))
+            {
+                hit = default;
+                return false;
+            }
 
             int closestHitIndex = 0;
-            for (int i = 0; i < hitCount; i++)
+            for (int i = 0; i < hits.Length; i++)
             {
-                if (_rawResults[i].distance < _rawResults[closestHitIndex].distance)
+                if (_hitBuffer[i].distance < _hitBuffer[closestHitIndex].distance)
                 {
                     closestHitIndex = i;
                 }
             }
-
-            RaycastHit2D result = _rawResults[closestHitIndex];
-            hit = new Hit
-            {
-                Point    = result.point,
-                Normal   = result.normal,
-                Distance = result.distance,
-                Collider = result.collider,
-                Buffer   = _skinWidth,
-                Centroid = result.centroid,
-            };
-            DrawCastResultAsLineInEditor(delta, hitCount > 0? hit.Point : null);
-            return hitCount > 0;
-        }
-
-
-        /* What's the delta between the AABB and the expanded AABB (with skin width) from center in given direction? */
-        public void ComputeOffset(Vector2 direction, out Vector2 deltaInner, out Vector2 deltaOuter)
-        {
-            Vector2 center    = Vector2.zero;
-            Vector2 size      = new(_boxCollider.bounds.size.x, _boxCollider.bounds.size.y);
-            Vector2 maxOffset = new(_skinWidth, _skinWidth);
-
-            Ray    ray   = new(center, direction);
-            Bounds inner = new(center, size);
-            Bounds outer = new(center, size + maxOffset);
-            inner.IntersectRay(ray, out float distanceToInner);
-            outer.IntersectRay(ray, out float distanceToOuter);
-
-            deltaInner = distanceToInner * direction.normalized;
-            deltaOuter = distanceToOuter * direction.normalized;
+            hit = _hitBuffer[closestHitIndex];
+            return true;
         }
         
-        
-        private void DrawCastResultAsLineInEditor(Vector2 delta, Vector2? hitPoint)
+
+        private bool CastAABB(Vector2 delta, out ReadOnlySpan<RaycastHit2D> hits)
         {
-            float duration = Time.fixedDeltaTime;
-            Vector2 centroid = Bounds.center;
-            Debug.DrawLine(centroid, centroid + delta, Color.red, duration);
-            if (hitPoint != null)
+            _castFilter.SetLayerMask(_layerMask);
+            int hitCount = _boxCollider.Cast(delta, _castFilter, _hitBuffer, delta.magnitude, ignoreSiblingColliders: true);
+            hits = _hitBuffer.AsSpan(0, hitCount);
+            
+            #if UNITY_EDITOR
+            if (_drawCastsInEditor)
             {
-                Debug.DrawLine(centroid, hitPoint.Value, Color.green, duration);
+                float duration = Time.fixedDeltaTime;
+                foreach (RaycastHit2D hit in hits)
+                {
+                    Debug.DrawLine(hit.centroid, hit.centroid + delta, Color.red, duration);
+                    Debug.DrawLine(hit.centroid, hit.point, Color.green, duration);
+                }
             }
+            #endif
+            return !hits.IsEmpty;
         }
+
 
         void OnValidate()
         {
@@ -168,9 +148,9 @@ namespace PQ.TestScenes.Box
                 return;
             }
 
-            if (_preallocatedHitBufferSize != _rawResults.Length)
+            if (_preallocatedHitBufferSize != _hitBuffer.Length)
             {
-                _rawResults = new RaycastHit2D[_preallocatedHitBufferSize];
+                _hitBuffer = new RaycastHit2D[_preallocatedHitBufferSize];
             }
         }
 
@@ -180,15 +160,12 @@ namespace PQ.TestScenes.Box
             // surrounded by an outer bounding box offset by our skin with, with a pair of arrows from the that
             // should be identical to the transform's axes in the editor window
             Bounds box = Bounds;
-            Vector2 center    = new(box.center.x, box.center.y);
-            Vector2 skinRatio = new(1f + (_skinWidth / box.extents.x), 1f + (_skinWidth / box.extents.y));
-            Vector2 xAxis     = box.extents.x * Forward;
-            Vector2 yAxis     = box.extents.y * Up;
+            Vector2 center = new(box.center.x, box.center.y);
+            Vector2 xAxis  = box.extents.x * Forward;
+            Vector2 yAxis  = box.extents.y * Up;
 
-            GizmoExtensions.DrawRect(center, xAxis, yAxis, Color.gray);
-            GizmoExtensions.DrawRect(center, skinRatio.x * xAxis, skinRatio.y * yAxis, Color.magenta);
-            GizmoExtensions.DrawArrow(from: center, to: center + xAxis, color: Color.red);
-            GizmoExtensions.DrawArrow(from: center, to: center + yAxis, color: Color.green);
+            GizmoExtensions.DrawArrow(from: center, to: center + xAxis, color: Color.blue);
+            GizmoExtensions.DrawArrow(from: center, to: center + yAxis, color: Color.cyan);
         }
     }
 }

--- a/Assets/_Experimental/Box/Mover.cs
+++ b/Assets/_Experimental/Box/Mover.cs
@@ -77,13 +77,12 @@ namespace PQ.TestScenes.Box
             for (int i = 0; i < _maxIterations && !ApproximatelyZero(delta); i++)
             {
                 // move directly to target if unobstructed
-                if (!_body.Cast_Closest(delta, out Hit hit))
+                if (!_body.CastClosest(delta, out RaycastHit2D hit))
                 {
                     _body.MoveBy(delta);
                     delta = Vector2.zero;
                     continue;
                 }
-
             }
         }
 

--- a/Assets/_Experimental/Box/Scene.unity
+++ b/Assets/_Experimental/Box/Scene.unity
@@ -196,6 +196,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2897265776197244332, guid: 8dd8740eb7eb8414297562c846f468b9, type: 3}
+      propertyPath: m_EdgeRadius
+      value: 0.02
+      objectReference: {fileID: 0}
     - target: {fileID: 5732869891268758683, guid: 8dd8740eb7eb8414297562c846f468b9, type: 3}
       propertyPath: m_Name
       value: Player

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -40,7 +40,7 @@ Physics2DSettings:
     m_IslandSolverContactsPerJob: 50
   m_SimulationMode: 0
   m_QueriesHitTriggers: 0
-  m_QueriesStartInColliders: 1
+  m_QueriesStartInColliders: 0
   m_CallbacksOnDisable: 0
   m_ReuseCollisionCallbacks: 1
   m_AutoSyncTransforms: 0


### PR DESCRIPTION
Clean up collision handling, such that query overlaps ignored, raycastHit2Ds are used, and edge radius + contact offset is utilized instead of skin width.