### PR TITLE
Physics: Add overlap resolution when moving along surfaces

### DIFF
--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -10,7 +10,7 @@ namespace PQ.TestScenes.Box
         [SerializeField] private BoxCollider2D _boxCollider;
 
         [SerializeField] private LayerMask _layerMask = default;
-        [SerializeField] [Range(0, 1)]   private float _skinWidth = 0.02f;
+        [SerializeField] [Range(0, 1)]   private float _skinWidth = 0.01f;
         [SerializeField] [Range(1, 100)] private int _preallocatedHitBufferSize = 16;
 
         #if UNITY_EDITOR
@@ -41,21 +41,23 @@ namespace PQ.TestScenes.Box
 
         void Awake()
         {
-            if (!transform.TryGetComponent<Rigidbody2D>(out var rigidBody))
+            if (!transform.TryGetComponent<Rigidbody2D>(out var _))
             {
                 throw new MissingComponentException($"Expected attached rigidbody2D - not found on {transform}");
             }
-            if (!transform.TryGetComponent<BoxCollider2D>(out var boxCollider))
+            if (!transform.TryGetComponent<BoxCollider2D>(out var _))
             {
                 throw new MissingComponentException($"Expected attached collider2D - not found on {transform}");
             }
 
-            _rigidBody   = rigidBody;
-            _boxCollider = boxCollider;
-            _castFilter  = new ContactFilter2D();
-            _hitBuffer   = new RaycastHit2D[_preallocatedHitBufferSize];
+            _castFilter = new ContactFilter2D();
+            _hitBuffer  = new RaycastHit2D[_preallocatedHitBufferSize];
             _castFilter.useLayerMask = true;
             _castFilter.SetLayerMask(_layerMask);
+
+            float buffer = Mathf.Clamp01(_skinWidth);
+            _boxCollider.edgeRadius = buffer;
+            _boxCollider.size       = new Vector2(1f - buffer, 1f - buffer);
 
             _rigidBody.isKinematic = true;
             _rigidBody.simulated   = true;
@@ -226,8 +228,13 @@ namespace PQ.TestScenes.Box
             return flags;
         }
 
+
         void OnValidate()
         {
+            float buffer = Mathf.Clamp01(_skinWidth);
+            _boxCollider.edgeRadius = buffer;
+            _boxCollider.size       = new Vector2(1f - buffer, 1f - buffer);
+
             if (!Application.IsPlaying(this) || !_initialized)
             {
                 return;
@@ -250,8 +257,8 @@ namespace PQ.TestScenes.Box
             Vector2 xAxis     = box.extents.x * Forward;
             Vector2 yAxis     = box.extents.y * Up;
 
-            GizmoExtensions.DrawRect(center, xAxis, yAxis, Color.gray);
-            GizmoExtensions.DrawRect(center, skinRatio.x * xAxis, skinRatio.y * yAxis, Color.magenta);
+            GizmoExtensions.DrawRect(center, xAxis, yAxis, Color.black);
+            GizmoExtensions.DrawRect(center, skinRatio.x * xAxis, skinRatio.y * yAxis, Color.black);
             GizmoExtensions.DrawArrow(from: center, to: center + xAxis, color: Color.red);
             GizmoExtensions.DrawArrow(from: center, to: center + yAxis, color: Color.green);
         }

--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -228,6 +228,25 @@ namespace PQ.TestScenes.Box
             return flags;
         }
 
+        /*
+        Compute vector representing overlap amount between body and given collider, if any.
+
+        Uses separating axis theorem to determine overlap - may require more invocations for
+        complex polygons.
+        */
+        public bool ComputeOverlap(Collider2D collider, out Vector2 amount)
+        {
+            ColliderDistance2D minimumSeparation = _boxCollider.Distance(collider);
+            if (!minimumSeparation.isValid || minimumSeparation.distance <= 0)
+            {
+                amount = minimumSeparation.distance * minimumSeparation.normal;
+                return false;
+            }
+
+            amount = minimumSeparation.distance * minimumSeparation.normal;
+            return true;
+        }
+
 
         void OnValidate()
         {

--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -236,10 +236,18 @@ namespace PQ.TestScenes.Box
         */
         public bool ComputeOverlap(Collider2D collider, out Vector2 amount)
         {
+            amount = Vector2.zero;
+            if (collider == null)
+            {
+                return false;
+            }
+
             ColliderDistance2D minimumSeparation = _boxCollider.Distance(collider);
+            Debug.Log($"distance={minimumSeparation.distance}" +
+                      $"normal={minimumSeparation.normal}" +
+                      $"isValid={minimumSeparation.isValid}");
             if (!minimumSeparation.isValid || minimumSeparation.distance <= 0)
             {
-                amount = minimumSeparation.distance * minimumSeparation.normal;
                 return false;
             }
 

--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -236,18 +236,16 @@ namespace PQ.TestScenes.Box
         */
         public bool ComputeOverlap(Collider2D collider, out Vector2 amount)
         {
-            amount = Vector2.zero;
             if (collider == null)
             {
+                amount = Vector2.zero;
                 return false;
             }
 
             ColliderDistance2D minimumSeparation = _boxCollider.Distance(collider);
-            Debug.Log($"distance={minimumSeparation.distance}" +
-                      $"normal={minimumSeparation.normal}" +
-                      $"isValid={minimumSeparation.isValid}");
             if (!minimumSeparation.isValid || minimumSeparation.distance <= 0)
             {
+                amount = Vector2.zero;
                 return false;
             }
 

--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -159,8 +159,7 @@ namespace PQ.TestScenes.Box
             float   distance  = delta.magnitude;
             Vector2 direction = delta / distance;
 
-            //int hitCount = _boxCollider.Cast(direction, _castFilter, _hitBuffer, distance, ignoreSiblingColliders: true);
-            int hitCount = Physics2D.BoxCastNonAlloc(center, size, 0, direction, _hitBuffer, distance, _castFilter.layerMask, minDepth: 0);
+            int hitCount = Physics2D.BoxCast(center, size, 0, direction, _castFilter, _hitBuffer, distance);
             hits = _hitBuffer.AsSpan(0, hitCount);
 
             #if UNITY_EDITOR

--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -31,11 +31,12 @@ namespace PQ.TestScenes.Box
                 $"AABB: bounds(center:{Bounds.center}, extents:{Bounds.extents})," +
             $"}}";
 
-        public Vector2 Position => _rigidBody.position;
-        public float   Depth    => _rigidBody.transform.position.z;
-        public Bounds  Bounds   => _boxCollider.bounds;
-        public Vector2 Forward  => _rigidBody.transform.right.normalized;
-        public Vector2 Up       => _rigidBody.transform.up.normalized;
+        public Vector2 Position  => _rigidBody.position;
+        public float   Depth     => _rigidBody.transform.position.z;
+        public Bounds  Bounds    => _boxCollider.bounds;
+        public Vector2 Forward   => _rigidBody.transform.right.normalized;
+        public Vector2 Up        => _rigidBody.transform.up.normalized;
+        public float   SkinWidth => _skinWidth;
 
 
         void Awake()

--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -144,19 +144,25 @@ namespace PQ.TestScenes.Box
         */
         public bool CastAABB(Vector2 delta, out ReadOnlySpan<RaycastHit2D> hits)
         {
+            _castFilter.SetLayerMask(_layerMask);
+
             if (delta == Vector2.zero)
             {
                 hits = _hitBuffer.AsSpan(0, 0);
                 return false;
             }
 
-            _castFilter.SetLayerMask(_layerMask);
+            Bounds bounds = _boxCollider.bounds;
 
-            float maxDistance = delta.magnitude;
-            Vector2 direction = delta / maxDistance;
-            int hitCount = _boxCollider.Cast(direction, _castFilter, _hitBuffer, maxDistance, ignoreSiblingColliders: true);
+            Vector2 center    = bounds.center;
+            Vector2 size      = bounds.size;
+            float   distance  = delta.magnitude;
+            Vector2 direction = delta / distance;
+
+            //int hitCount = _boxCollider.Cast(direction, _castFilter, _hitBuffer, distance, ignoreSiblingColliders: true);
+            int hitCount = Physics2D.BoxCastNonAlloc(center, size, 0, direction, _hitBuffer, distance, _castFilter.layerMask, minDepth: 0);
             hits = _hitBuffer.AsSpan(0, hitCount);
-            
+
             #if UNITY_EDITOR
             if (_drawCastsInEditor)
             {
@@ -165,7 +171,7 @@ namespace PQ.TestScenes.Box
                 {
                     Vector2 edgePoint = hit.point - (hit.distance * direction);
                     Vector2 hitPoint  = hit.point;
-                    Vector2 endPoint  = hit.point + (maxDistance * direction);
+                    Vector2 endPoint  = hit.point + (distance * direction);
                     
                     Debug.DrawLine(edgePoint, hitPoint, Color.green, duration);
                     Debug.DrawLine(hitPoint,  endPoint, Color.red,   duration);

--- a/Assets/_Experimental/Box/Body.cs
+++ b/Assets/_Experimental/Box/Body.cs
@@ -243,7 +243,8 @@ namespace PQ.TestScenes.Box
             }
 
             ColliderDistance2D minimumSeparation = _boxCollider.Distance(collider);
-            if (!minimumSeparation.isValid || minimumSeparation.distance <= 0)
+            Debug.Log(minimumSeparation.distance);
+            if (!minimumSeparation.isValid || minimumSeparation.distance >= 0)
             {
                 amount = Vector2.zero;
                 return false;

--- a/Assets/_Experimental/Box/Character.cs
+++ b/Assets/_Experimental/Box/Character.cs
@@ -6,11 +6,12 @@ namespace PQ.TestScenes.Box
 {
     public class Character : MonoBehaviour
     {
-        [Range(0, 10)] [SerializeField] private float _timeScale           = 1f;
-        [Range(0, 10)] [SerializeField] private float _horizontalSpeed     = 5f;
-        [Range(0, 50)] [SerializeField] private float _gravitySpeed        = 10f;
-        [Range(0, 90)] [SerializeField] private float _maxSlopeAngle       = 90f;
-        [Range(0, 50)] [SerializeField] private int   _maxSolverIterations = 10;
+        [Range(0, 10)] [SerializeField] private float _timeScale            = 1f;
+        [Range(0, 10)] [SerializeField] private float _horizontalSpeed      = 5f;
+        [Range(0, 50)] [SerializeField] private float _gravitySpeed         = 10f;
+        [Range(0, 90)] [SerializeField] private float _maxSlopeAngle        = 90f;
+        [Range(0, 50)] [SerializeField] private int   _maxMoveIterations    = 10;        
+        [Range(0, 10)] [SerializeField] private int   _maxOverlapIterations = 2;
 
         private bool    _grounded  = true;
         private Vector2 _inputAxis = Vector2.zero;
@@ -20,7 +21,8 @@ namespace PQ.TestScenes.Box
             $"Character{{" +
                 $"horizontalSpeed:{_horizontalSpeed}," +
                 $"gravitySpeed:{_gravitySpeed}," +
-                $"maxSolverIterations:{_maxSolverIterations}," +
+                $"maxMoveIterations:{_maxMoveIterations}," +
+                $"maxOverlapIterations:{_maxOverlapIterations}" +
             $"}}";
 
         
@@ -39,7 +41,7 @@ namespace PQ.TestScenes.Box
                 y: (Keyboard.current[Key.S].isPressed ? -1f : 0f) + (Keyboard.current[Key.W].isPressed ? 1f : 0f)
             );
 
-            _mover.SetParams(_maxSlopeAngle, _maxSolverIterations);
+            _mover.SetParams(_maxSlopeAngle, _maxMoveIterations, _maxOverlapIterations);
             Time.timeScale = _timeScale;
         }
 

--- a/Assets/_Experimental/Box/Mover.cs
+++ b/Assets/_Experimental/Box/Mover.cs
@@ -64,6 +64,11 @@ namespace PQ.TestScenes.Box
          */
         public void Move(Vector2 deltaPosition)
         {
+            DetectClosestCollision(deltaPosition, out RaycastHit2D hitHorizontal);
+            DetectClosestCollision(deltaPosition, out RaycastHit2D hitVertical);
+            PushOutIfOverlap(hitHorizontal);
+            PushOutIfOverlap(hitVertical);
+
             if (ApproximatelyZero(deltaPosition))
             {
                 return;
@@ -165,7 +170,7 @@ namespace PQ.TestScenes.Box
 
         private void PushOutIfOverlap(RaycastHit2D hit)
         {
-            Vector2 overlapAmount = Vector2.zero;
+            Vector2 overlapAmount = Vector2.positiveInfinity;
             for (int i = 0; i < _maxOverlapIterations && !ApproximatelyZero(overlapAmount); i++)
             {
                 if (_body.ComputeOverlap(hit.collider, out overlapAmount))

--- a/Assets/_Experimental/Box/Mover.cs
+++ b/Assets/_Experimental/Box/Mover.cs
@@ -64,11 +64,6 @@ namespace PQ.TestScenes.Box
          */
         public void Move(Vector2 deltaPosition)
         {
-            DetectClosestCollision(deltaPosition, out RaycastHit2D hitHorizontal);
-            DetectClosestCollision(deltaPosition, out RaycastHit2D hitVertical);
-            PushOutIfOverlap(hitHorizontal);
-            PushOutIfOverlap(hitVertical);
-
             if (ApproximatelyZero(deltaPosition))
             {
                 return;
@@ -170,6 +165,7 @@ namespace PQ.TestScenes.Box
 
         private void PushOutIfOverlap(RaycastHit2D hit)
         {
+            // todo: add skin width support
             Vector2 overlapAmount = Vector2.positiveInfinity;
             for (int i = 0; i < _maxOverlapIterations && !ApproximatelyZero(overlapAmount); i++)
             {

--- a/Assets/_Experimental/Box/Player.prefab
+++ b/Assets/_Experimental/Box/Player.prefab
@@ -158,8 +158,8 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0.0002
+  m_Size: {x: 0.9, y: 0.9}
+  m_EdgeRadius: 0.1
 --- !u!114 &-1598793908994606294
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -177,7 +177,7 @@ MonoBehaviour:
   _layerMask:
     serializedVersion: 2
     m_Bits: 4096
-  _skinWidth: 0.075
+  _skinWidth: 0.1
   _preallocatedHitBufferSize: 16
   _drawCastsInEditor: 1
   _drawMovesInEditor: 1

--- a/Assets/_Experimental/Box/Player.prefab
+++ b/Assets/_Experimental/Box/Player.prefab
@@ -158,8 +158,8 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 1
   serializedVersion: 2
-  m_Size: {x: 0.9, y: 0.9}
-  m_EdgeRadius: 0.1
+  m_Size: {x: 0.925, y: 0.925}
+  m_EdgeRadius: 0.075
 --- !u!114 &-1598793908994606294
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -177,7 +177,7 @@ MonoBehaviour:
   _layerMask:
     serializedVersion: 2
     m_Bits: 4096
-  _skinWidth: 0.1
+  _skinWidth: 0.075
   _preallocatedHitBufferSize: 16
   _drawCastsInEditor: 1
   _drawMovesInEditor: 1


### PR DESCRIPTION
Adds iterations using collider distance 2d to push out overlapping portions of the box.


https://user-images.githubusercontent.com/8084757/236536910-7d68dbd0-4f0a-419c-8cde-c28c47637609.mp4

