### PR TITLE
[Physics] Kinematic Solver: Include overlapping colliders when projecting aabb along delta

### DIFF
--- a/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
+++ b/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
@@ -154,11 +154,9 @@ namespace PQ.Common.Physics.Internal
             float   distanceLeft       = delta.magnitude;
             Vector2 direction          = delta / distanceLeft;
             float   distanceToAABBEdge = _body.ComputeDistanceToEdge(direction);
-            Debug.Log($"distancetoedge={distanceToAABBEdge}");
+
             float stepDistance;
-
-
-            if (_body.CastAABB(direction, 100f, out ReadOnlySpan<RaycastHit2D> hits) && hits[0].distance <= distanceToAABBEdge)
+            if (_body.CastAABB(direction, distanceLeft, out ReadOnlySpan<RaycastHit2D> hits, includeAlreadyOverlappingColliders: true) && hits[0].distance <= distanceToAABBEdge)
             {
                 obstruction  = hits[0];
                 stepDistance = hits[0].distance;

--- a/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
+++ b/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
@@ -65,9 +65,13 @@ namespace PQ.Common.Physics.Internal
         - For flexibility, any external movement such as gravity must be accounted for in given delta
         - Movement is only opted-out if within floating point tolerances of zero, as anything larger will lead to
           skipping movement when deltas are small due to the timestep/world-scale/frame-rate used to compute it prior
-         */
+        */
         public void SolveMovement(Vector2 deltaPosition)
         {
+            Vector2 delta = new Vector2(1, 0);
+            MoveAABBAlongDelta(ref delta, out RaycastHit2D hit);
+            return;
+
             SnapToSurfaceIfNearOrInside();
             if (ApproximatelyZero(deltaPosition))
             {
@@ -145,31 +149,25 @@ namespace PQ.Common.Physics.Internal
         
 
         /* Project AABB along delta until (if any) obstruction. Max distance caps at body-radius to prevent tunneling. */
-        private void MoveAABBAlongDelta(ref Vector2 delta, out RaycastHit2D hit)
+        private void MoveAABBAlongDelta(ref Vector2 delta, out RaycastHit2D obstruction)
         {
-            hit = default;
+            float   distanceLeft       = delta.magnitude;
+            Vector2 direction          = delta / distanceLeft;
+            float   distanceToAABBEdge = _body.ComputeDistanceToEdge(direction);
 
-            if (ApproximatelyZero(delta))
+            float stepDistance;
+            if (_body.CastAABB(direction, distanceLeft, out ReadOnlySpan<RaycastHit2D> hits) && hits[0].distance <= distanceToAABBEdge)
             {
-                return;
-            }
-
-            float   distanceLeft    = delta.magnitude;
-            Vector2 direction       = delta / distanceLeft;
-            float   bodyRadius      = _body.ComputeDistanceToEdge(direction);
-            float   maxStepDistance = Mathf.Min(bodyRadius, distanceLeft);
-
-            Vector2 step;
-            if (_body.CastAABB(direction, maxStepDistance, out ReadOnlySpan<RaycastHit2D> hits))
-            {
-                hit  = hits[0];
-                step = hits[0].distance * direction;
+                obstruction  = hits[0];
+                stepDistance = hits[0].distance;
             }
             else
             {
-                hit  = default;
-                step = maxStepDistance * direction;
+                obstruction  = default;
+                stepDistance = distanceLeft < distanceToAABBEdge ? distanceLeft : distanceToAABBEdge;
             }
+
+            Vector2 step = stepDistance * direction;
 
             #if UNITY_EDITOR
             Vector2 origin = _body.Position;

--- a/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
+++ b/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
@@ -68,10 +68,6 @@ namespace PQ.Common.Physics.Internal
         */
         public void SolveMovement(Vector2 deltaPosition)
         {
-            Vector2 delta = new Vector2(0.005f, 0);
-            MoveAABBAlongDelta(ref delta, out RaycastHit2D hit);
-            return;
-
             SnapToSurfaceIfNearOrInside();
             if (ApproximatelyZero(deltaPosition))
             {
@@ -90,8 +86,9 @@ namespace PQ.Common.Physics.Internal
             MoveVertical(vertical);
 
             SnapToSurfaceIfNearOrInside();
-            _collisions = _body.CheckSides();
             _body.MovePosition(startPositionThisFrame: position, targetPositionThisFrame: _body.Position);
+
+            _collisions = _body.CheckSides();
         }
 
         public bool InContact(CollisionFlags2D flags)
@@ -155,16 +152,12 @@ namespace PQ.Common.Physics.Internal
             Vector2 direction          = delta / distanceLeft;
             float   distanceToAABBEdge = _body.ComputeDistanceToEdge(direction);
 
-            float stepDistance;
-            if (_body.CastAABB(direction, distanceLeft, out ReadOnlySpan<RaycastHit2D> hits, includeAlreadyOverlappingColliders: true) && hits[0].distance <= distanceToAABBEdge)
+            obstruction = default;
+            float stepDistance = Mathf.Min(distanceToAABBEdge, distanceLeft);
+            if (_body.CastAABB(direction, stepDistance, out ReadOnlySpan<RaycastHit2D> hits, includeAlreadyOverlappingColliders: true))
             {
                 obstruction  = hits[0];
                 stepDistance = hits[0].distance;
-            }
-            else
-            {
-                obstruction  = default;
-                stepDistance = distanceLeft < distanceToAABBEdge ? distanceLeft : distanceToAABBEdge;
             }
 
             Vector2 step = stepDistance * direction;

--- a/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
+++ b/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
@@ -68,7 +68,7 @@ namespace PQ.Common.Physics.Internal
         */
         public void SolveMovement(Vector2 deltaPosition)
         {
-            Vector2 delta = new Vector2(1, 0);
+            Vector2 delta = new Vector2(0.005f, 0);
             MoveAABBAlongDelta(ref delta, out RaycastHit2D hit);
             return;
 
@@ -154,9 +154,11 @@ namespace PQ.Common.Physics.Internal
             float   distanceLeft       = delta.magnitude;
             Vector2 direction          = delta / distanceLeft;
             float   distanceToAABBEdge = _body.ComputeDistanceToEdge(direction);
-
+            Debug.Log($"distancetoedge={distanceToAABBEdge}");
             float stepDistance;
-            if (_body.CastAABB(direction, distanceLeft, out ReadOnlySpan<RaycastHit2D> hits) && hits[0].distance <= distanceToAABBEdge)
+
+
+            if (_body.CastAABB(direction, 100f, out ReadOnlySpan<RaycastHit2D> hits) && hits[0].distance <= distanceToAABBEdge)
             {
                 obstruction  = hits[0];
                 stepDistance = hits[0].distance;

--- a/Assets/Code/Common/Physics/Internal/KinematicRigidbody2D.cs
+++ b/Assets/Code/Common/Physics/Internal/KinematicRigidbody2D.cs
@@ -203,13 +203,10 @@ namespace PQ.Common.Physics.Internal
 
         Note that casts ignore body's bounds, and all Physics2D cast results are sorted by ascending distance.
         */
-        public bool CastAABB(Vector2 direction, float distance, out ReadOnlySpan<RaycastHit2D> hits)
+        public bool CastAABB(Vector2 direction, float distance, out ReadOnlySpan<RaycastHit2D> hits, bool includeAlreadyOverlappingColliders)
         {
-            if ((distance * direction) == Vector2.zero)
-            {
-                hits = _hitBuffer.AsSpan(0, 0);
-                return false;
-            }
+            bool previousQueriesStartInColliders = Physics2D.queriesStartInColliders;
+            Physics2D.queriesStartInColliders = includeAlreadyOverlappingColliders;
 
             Bounds bounds = _boxCollider.bounds;
 
@@ -227,7 +224,7 @@ namespace PQ.Common.Physics.Internal
             }
             #endif
             
-            Debug.Log(hits.IsEmpty? default : $"{hits[0].distance}");
+            Physics2D.queriesStartInColliders = previousQueriesStartInColliders;
             return !hits.IsEmpty;
         }
 

--- a/Assets/Code/Common/Physics/Internal/KinematicRigidbody2D.cs
+++ b/Assets/Code/Common/Physics/Internal/KinematicRigidbody2D.cs
@@ -214,11 +214,14 @@ namespace PQ.Common.Physics.Internal
             Bounds bounds = _boxCollider.bounds;
 
             Vector2 center = bounds.center;
-            Vector2 size   = bounds.size - new Vector3(2f * _boxCollider.edgeRadius, 2f * _boxCollider.edgeRadius, 0f);
+            Vector2 size   = bounds.size;
 
+
+            _boxCollider.enabled = false;
             int hitCount = Physics2D.BoxCast(center, size, 0, direction, _contactFilter, _hitBuffer, distance);
             hits = _hitBuffer.AsSpan(0, hitCount);
-            
+            _boxCollider.enabled = true;
+
             #if UNITY_EDITOR
             if (DrawCastsInEditor)
             {


### PR DESCRIPTION
Provide override option for queries to start in colliders when performing a boxcast, such that starting in a state where there is already overlap reports a hit. Before, it would ignore this, leading to ghosting through colliders in some cases.

By doing this, we avoid doing a more complicated overlap box check, which we really only want to do at the beginning and end of the solve.