### PR TITLE
Experimental - Replace all references of aabb box collider with capsule

### DIFF
--- a/Assets/Code/Common/Physics/Internal/KinematicRigidbody2D.cs
+++ b/Assets/Code/Common/Physics/Internal/KinematicRigidbody2D.cs
@@ -20,7 +20,7 @@ namespace PQ.Common.Physics.Internal
     {
         private Transform        _transform;
         private Rigidbody2D      _rigidbody;
-        private BoxCollider2D    _boxCollider;
+        private CapsuleCollider2D _boxCollider;
         private ContactFilter2D  _contactFilter;
         private RaycastHit2D[]   _hitBuffer;
         private Collider2D[]     _overlapBuffer;
@@ -58,9 +58,9 @@ namespace PQ.Common.Physics.Internal
         public Vector2 Center       => _boxCollider.bounds.center;
         public Vector2 Forward      => _rigidbody.transform.right.normalized;
         public Vector2 Up           => _rigidbody.transform.up.normalized;
-        public Vector2 Extents      => _boxCollider.bounds.extents + new Vector3(_boxCollider.edgeRadius, _boxCollider.edgeRadius, 0f);
+        public Vector2 Extents      => _boxCollider.bounds.extents + new Vector3(0f, 0f, 0f);
         public float   Depth        => _rigidbody.transform.position.z;
-        public float   SkinWidth    => _boxCollider.edgeRadius;
+        public float   SkinWidth    => 0f;
         public Vector2 BoundsOffset => _boxCollider.offset;
 
         public bool IsFlippedHorizontal => _rigidbody.transform.localEulerAngles.y >= 90f;
@@ -81,7 +81,7 @@ namespace PQ.Common.Physics.Internal
             {
                 throw new MissingComponentException($"Expected attached {nameof(Rigidbody2D)} - not found on {nameof(transform)}");
             }
-            if (!transform.TryGetComponent(out BoxCollider2D boxCollider2D))
+            if (!transform.TryGetComponent(out CapsuleCollider2D boxCollider2D))
             {
                 throw new MissingComponentException($"Expected attached {nameof(BoxCollider2D)} - not found on {nameof(transform)}");
             }
@@ -123,15 +123,13 @@ namespace PQ.Common.Physics.Internal
             _gravityScale = gravityScale;
         }
 
-        public void SetLocalBounds(Vector2 offset, Vector2 size, float outerEdgeRadius)
+        public void SetLocalBounds(Vector2 offset, Vector2 size)
         {
             if (_boxCollider.offset != offset ||
-                _boxCollider.size   != size   ||
-                !Mathf.Approximately(_boxCollider.edgeRadius, outerEdgeRadius))
+                _boxCollider.size   != size)
             {
-                _boxCollider.offset     = offset;
-                _boxCollider.size       = size;
-                _boxCollider.edgeRadius = outerEdgeRadius;
+                _boxCollider.offset = offset;
+                _boxCollider.size   = size;
             }
         }
 

--- a/Assets/Code/Common/Physics/PhysicsBody2D.cs
+++ b/Assets/Code/Common/Physics/PhysicsBody2D.cs
@@ -217,7 +217,7 @@ namespace PQ.Common.Physics
                     $"received from={localMin} to={localMax} skinWidth={skinWidth}");
             }
 
-            _kinematicBody.SetLocalBounds(localCenter, 2f * localExtents, skinWidth);
+            _kinematicBody.SetLocalBounds(localCenter, 2f * localExtents);
             _skinWidth     = skinWidth;
             _AABBCornerMin = localMin;
             _AABBCornerMax = localMax;

--- a/Assets/Code/Game/Entities/Penguin/Components/PenguinSkeletalStructure.cs
+++ b/Assets/Code/Game/Entities/Penguin/Components/PenguinSkeletalStructure.cs
@@ -15,7 +15,7 @@ namespace PQ.Game.Entities.Penguin
         [SerializeField] private PenguinColliderConstraints _colliderConstraints = PenguinColliderConstraints.None;
 
         [Header("Collider References")]
-        [SerializeField] private BoxCollider2D     _outerCollider;
+        [SerializeField] private CapsuleCollider2D _outerCollider;
         [SerializeField] private CapsuleCollider2D _headCollider;
         [SerializeField] private CapsuleCollider2D _torsoCollider;
         [SerializeField] private CapsuleCollider2D _frontFlipperUpperCollider;
@@ -23,7 +23,7 @@ namespace PQ.Game.Entities.Penguin
         [SerializeField] private CapsuleCollider2D _frontFootCollider;
         [SerializeField] private CapsuleCollider2D _backFootCollider;
 
-        public BoxCollider2D     OuterCollider             => _outerCollider;
+        public CapsuleCollider2D OuterCollider             => _outerCollider;
         public CapsuleCollider2D ColliderHead              => _headCollider;
         public CapsuleCollider2D ColliderTorso             => _torsoCollider;
         public CapsuleCollider2D ColliderFrontFlipperUpper => _frontFlipperUpperCollider;

--- a/Assets/Prefabs/Actors/Penguin.prefab
+++ b/Assets/Prefabs/Actors/Penguin.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 99392607343190492}
   - component: {fileID: 3285427051894065791}
-  - component: {fileID: 3059268163222020866}
+  - component: {fileID: 4802853302313394081}
   - component: {fileID: 2916047126819965676}
   - component: {fileID: 2002890420633338778}
   - component: {fileID: 5935993559784443868}
@@ -66,8 +66,8 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 1
   m_Constraints: 0
---- !u!61 &3059268163222020866
-BoxCollider2D:
+--- !u!70 &4802853302313394081
+CapsuleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -98,19 +98,9 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0.57500005}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 1
-  serializedVersion: 2
+  m_Offset: {x: 0, y: 0.575}
   m_Size: {x: 0.44, y: 1}
-  m_EdgeRadius: 0.04
+  m_Direction: 0
 --- !u!114 &2916047126819965676
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -176,7 +166,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _colliderConstraints: 0
-  _outerCollider: {fileID: 3059268163222020866}
+  _outerCollider: {fileID: 0}
   _headCollider: {fileID: 4882723521779048514}
   _torsoCollider: {fileID: 728521996775082805}
   _frontFlipperUpperCollider: {fileID: 2800808826828882743}

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1233,6 +1233,18 @@ PrefabInstance:
       propertyPath: m_Interpolate
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4485612146676894531, guid: ff13ec81cbe8014418b88c5e68427ff6, type: 3}
+      propertyPath: _outerCollider
+      value: 
+      objectReference: {fileID: 2039410382}
+    - target: {fileID: 4802853302313394081, guid: ff13ec81cbe8014418b88c5e68427ff6, type: 3}
+      propertyPath: m_Size.x
+      value: 0.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 4802853302313394081, guid: ff13ec81cbe8014418b88c5e68427ff6, type: 3}
+      propertyPath: m_Offset.y
+      value: 0.48
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1254,3 +1266,8 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2039410372}
   m_Enabled: 1
+--- !u!70 &2039410382 stripped
+CapsuleCollider2D:
+  m_CorrespondingSourceObject: {fileID: 4802853302313394081, guid: ff13ec81cbe8014418b88c5e68427ff6, type: 3}
+  m_PrefabInstance: {fileID: 2039410371}
+  m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
After seeing this: https://gamedev.stackexchange.com/questions/150661/using-collision-contacts-to-determine-if-on-a-floor

I was wondering if maybe capsule would be better after all for 2D, despite having found in the past (like a year ago) AABB via box collider is easier to work with, especially with a little bit of an edge radius.

So I tried it out, partly just to see how easy it'd be. Not to bad, but still more changes than I'd like, but I guess it's not something that would need to change often anyways, so it's fine.

Regardless, my brief testing showed little difference and just more complex geoemetry (so in a way less determinism) - so will be stopping this effort for now, but keeping it here for archives sake.