### PR TITLE
Setup up test scene for overlap resolution

### DIFF
--- a/Assets/_Experimental/Sandbox_Movement/Movement_002/Body.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Movement_002/Body.cs
@@ -10,7 +10,7 @@ namespace PQ._Experimental.Movement_002
         [SerializeField] private BoxCollider2D _boxCollider;
 
         [SerializeField] private LayerMask _layerMask = default;
-        [SerializeField] [Range(0,   1)] private float _skinWidth = 0.01f;
+        [SerializeField] [Range(0,   1)] private float _skinWidth = 0.075f;
         [SerializeField] [Range(1, 100)] private int _preallocatedHitBufferSize = 16;
 
         private ContactFilter2D _contactFilter;

--- a/Assets/_Experimental/Sandbox_Movement/Movement_002/Scene_SimplifiedSolver.unity
+++ b/Assets/_Experimental/Sandbox_Movement/Movement_002/Scene_SimplifiedSolver.unity
@@ -222,7 +222,7 @@ MonoBehaviour:
   _layerMask:
     serializedVersion: 2
     m_Bits: 4096
-  _skinWidth: 0.01
+  _skinWidth: 0.075
   _preallocatedHitBufferSize: 16
 --- !u!114 &1732712294
 MonoBehaviour:

--- a/Assets/_Experimental/Sandbox_Movement/Movement_002/Scene_SimplifiedSolver.unity
+++ b/Assets/_Experimental/Sandbox_Movement/Movement_002/Scene_SimplifiedSolver.unity
@@ -135,18 +135,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: BoxBoyV2
       objectReference: {fileID: 0}
-    - target: {fileID: 6068203031854652124, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
-      propertyPath: m_Size.x
-      value: 0.99
-      objectReference: {fileID: 0}
-    - target: {fileID: 6068203031854652124, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
-      propertyPath: m_Size.y
-      value: 0.99
-      objectReference: {fileID: 0}
-    - target: {fileID: 6068203031854652124, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
-      propertyPath: m_EdgeRadius
-      value: 0.01
-      objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_RootOrder
       value: 2

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001.meta
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 790f4eb1e04b7544d95d15bda007f156
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
@@ -1,0 +1,280 @@
+using System;
+using UnityEngine;
+
+
+namespace PQ._Experimental.Overlap_001
+{
+    public class Body : MonoBehaviour
+    {
+        [SerializeField] private Rigidbody2D   _rigidbody;
+        [SerializeField] private BoxCollider2D _boxCollider;
+
+        [SerializeField] private LayerMask _layerMask = default;
+        [SerializeField] [Range(0,   1)] private float _skinWidth = 0.01f;
+        [SerializeField] [Range(1, 100)] private int _preallocatedHitBufferSize = 16;
+
+        private ContactFilter2D _contactFilter;
+        private RaycastHit2D[]  _hitBuffer;
+
+        public override string ToString() =>
+            $"Mover{{" +
+                $"Position:{Position}," +
+                $"Depth:{Depth}," +
+                $"Forward:{Forward}," +
+                $"Up:{Up}," +
+                $"AABB: bounds(center:{Bounds.center}, extents:{Bounds.extents})," +
+            $"}}";
+
+        public Vector2 Position  => _rigidbody.position;
+        public float   Depth     => _rigidbody.transform.position.z;
+        public Bounds  Bounds    => _boxCollider.bounds;
+        public Vector2 Forward   => _rigidbody.transform.right.normalized;
+        public Vector2 Up        => _rigidbody.transform.up.normalized;
+        public float   SkinWidth => _skinWidth;
+
+
+        void Awake()
+        {
+            if (!transform.TryGetComponent<Rigidbody2D>(out var _))
+            {
+                throw new MissingComponentException($"Expected attached rigidbody2D - not found on {transform}");
+            }
+            if (!transform.TryGetComponent<BoxCollider2D>(out var _))
+            {
+                throw new MissingComponentException($"Expected attached collider2D - not found on {transform}");
+            }
+
+            _contactFilter = new ContactFilter2D();
+            _hitBuffer     = new RaycastHit2D[_preallocatedHitBufferSize];
+
+            _boxCollider.edgeRadius = _skinWidth;
+            _boxCollider.size = new Vector2(1f - _skinWidth, 1f - _skinWidth);
+
+            _rigidbody.interpolation = RigidbodyInterpolation2D.Interpolate;
+            _rigidbody.isKinematic = true;
+            _rigidbody.simulated   = true;
+            _rigidbody.useFullKinematicContacts = true;
+            _rigidbody.constraints = RigidbodyConstraints2D.None;
+
+            _contactFilter.useTriggers    = false;
+            _contactFilter.useNormalAngle = false;
+            _contactFilter.SetLayerMask(_layerMask);
+        }
+
+
+        /* Immediately set facing of horizontal/vertical axes. */
+        public void Flip(bool horizontal, bool vertical)
+        {
+            _rigidbody.transform.localEulerAngles = new Vector3(
+                x: vertical   ? 180f : 0f,
+                y: horizontal ? 180f : 0f,
+                z: 0f);
+        }
+
+        /* Immediately move body by given amount. */
+        public void MoveBy(Vector2 delta)
+        {
+            _rigidbody.position += delta;
+        }
+
+        /* Interpolated move this amount. */
+        public void MovePosition(Vector2 startPositionThisFrame, Vector2 targetPositionThisFrame)
+        {
+            _rigidbody.position = startPositionThisFrame;
+            _rigidbody.MovePosition(targetPositionThisFrame);
+        }
+
+
+        /* Project AABB along delta, and return ALL hits (if any). */
+        public bool CastAABB(Vector2 direction, float distance, out ReadOnlySpan<RaycastHit2D> hits, bool includeAlreadyOverlappingColliders)
+        {
+            bool previousQueriesStartInColliders = Physics2D.queriesStartInColliders;
+            Physics2D.queriesStartInColliders = includeAlreadyOverlappingColliders;
+
+            int hitCount = _boxCollider.Cast(direction, _contactFilter, _hitBuffer, distance, ignoreSiblingColliders: true);
+            hits = _hitBuffer.AsSpan(0, hitCount);
+
+            Physics2D.queriesStartInColliders = previousQueriesStartInColliders;
+
+            #if UNITY_EDITOR
+            float duration = Time.fixedDeltaTime;
+            foreach (RaycastHit2D hit in hits)
+            {
+                Vector2 edgePoint = hit.point - (hit.distance * direction);
+                Vector2 hitPoint = hit.point;
+                Vector2 endPoint = hit.point + (distance * direction);
+
+                Debug.DrawLine(edgePoint, hitPoint, Color.green, duration);
+                Debug.DrawLine(hitPoint,  endPoint, Color.red,   duration);
+            }
+            #endif
+            return !hits.IsEmpty;
+        }
+        
+        
+        /*
+        Check each side for _any_ colliders occupying the region between AABB and the outer perimeter defined by skin width.
+
+        If no layermask provided, uses the one assigned in editor.
+        */
+        public CollisionFlags2D CheckSides()
+        {
+            _contactFilter.useNormalAngle = true;
+            bool isFlippedHorizontal = _rigidbody.transform.localEulerAngles.y >= 90f;
+            bool isFlippedVertical   = _rigidbody.transform.localEulerAngles.x >= 90f;
+
+            CollisionFlags2D flags = CollisionFlags2D.None;
+            if (HasContactsInNormalRange(315, 45))
+            {
+                flags |= isFlippedHorizontal? CollisionFlags2D.Behind : CollisionFlags2D.Front;
+            }
+            if (HasContactsInNormalRange(45, 135))
+            {
+                flags |= isFlippedVertical ? CollisionFlags2D.Above : CollisionFlags2D.Below;
+            }
+            if (HasContactsInNormalRange(135, 225))
+            {
+                flags |= isFlippedHorizontal ? CollisionFlags2D.Front : CollisionFlags2D.Behind;
+            }
+            if (HasContactsInNormalRange(225, 315))
+            {
+                flags |= isFlippedVertical ? CollisionFlags2D.Below : CollisionFlags2D.Above;
+            }
+            _contactFilter.useNormalAngle = false;
+            Debug.Log(flags);
+            return flags;
+        }
+
+        
+        /* Compute distance from center to edge of our bounding box in given direction. */
+        public float ComputeDistanceToEdge(Vector2 direction)
+        {
+            Bounds bounds = _boxCollider.bounds;
+            bounds.IntersectRay(new Ray(bounds.center, direction), out float distanceFromCenterToEdge);
+
+            // discard sign since distance is negative if starts within bounds (contrary to other ray methods)
+            return Mathf.Abs(distanceFromCenterToEdge);
+        }
+        
+        /*
+        Compute signed distance representing overlap amount between body and given collider, if any.
+
+        Uses separating axis theorem to determine overlap - may require more invocations for complex polygons.
+        */
+        public bool ComputeDepenetration(Collider2D collider, Vector2 direction, float maxScanDistance, out float separation)
+        {
+            separation = 0f;
+
+            ColliderDistance2D minimumSeparation = _boxCollider.Distance(collider);
+            if (minimumSeparation.distance * minimumSeparation.normal == Vector2.zero)
+            {
+                return false;
+            }
+
+            Vector2 pointOnAABBEdge = minimumSeparation.pointA;
+            Vector2 directionToSurface = minimumSeparation.isOverlapped ? -direction : direction;
+            if (CastRayAt(collider, pointOnAABBEdge, directionToSurface, maxScanDistance, out RaycastHit2D hit, false))
+            {
+                separation = minimumSeparation.isOverlapped ? -Mathf.Abs(hit.distance) : Mathf.Abs(hit.distance);
+                Debug.Log(separation);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"Given {collider} not found between " +
+                    $"{pointOnAABBEdge} and {pointOnAABBEdge + maxScanDistance * direction}");
+            }
+
+            return (separation * direction) != Vector2.zero;
+        }
+        
+        
+        private bool HasContactsInNormalRange(float min, float max)
+        {
+            float previousMin = _contactFilter.minNormalAngle;
+            float previousMax = _contactFilter.maxNormalAngle;
+
+            _contactFilter.SetNormalAngle(min, max);
+            bool hasContactsInRange = _boxCollider.IsTouching(_contactFilter);
+
+            _contactFilter.SetNormalAngle(previousMin, previousMax);
+            return hasContactsInRange;
+        }
+
+        /*
+        Project a point along given direction until specific given collider is hit.
+        */
+        private bool CastRayAt(Collider2D collider, Vector2 origin, Vector2 direction, float distance, out RaycastHit2D hit, bool includeAlreadyOverlappingColliders)
+        {
+            // note that in 3D we have collider.RayCast for this, but in 2D we have no built in way of
+            // checking a specific collider (collider2D.RayCast confusingly casts _from_ it instead of _at_ it)
+            bool previousQueriesStartInColliders = Physics2D.queriesStartInColliders;
+            LayerMask previousLayerMask = _contactFilter.layerMask;
+            Physics2D.queriesStartInColliders = includeAlreadyOverlappingColliders;
+            _contactFilter.SetLayerMask(~collider.gameObject.layer);
+            _boxCollider.enabled = false;
+
+            int hitCount = Physics2D.Raycast(origin, direction, _contactFilter, _hitBuffer, distance);
+
+            Physics2D.queriesStartInColliders = previousQueriesStartInColliders;
+            _contactFilter.SetLayerMask(previousLayerMask);
+            _boxCollider.enabled = true;
+
+            hit = default;
+            for (int i = 0; i < hitCount; i++)
+            {
+                if (_hitBuffer[i].collider == collider)
+                {
+                    hit = _hitBuffer[i];
+                    break;
+                }
+            }
+
+            #if UNITY_EDITOR
+            float duration = Time.fixedDeltaTime;
+            Vector2 edgePoint = hit.point - (hit.distance * direction);
+            Vector2 hitPoint = hit.point;
+            Vector2 endPoint = hit.point + (distance * direction);
+
+            Debug.DrawLine(edgePoint, hitPoint, Color.green, duration);
+            Debug.DrawLine(hitPoint,  endPoint, Color.red,   duration);
+            #endif
+            return hit;
+        }
+
+
+        #if UNITY_EDITOR
+        void OnValidate()
+        {
+            _boxCollider.edgeRadius = _skinWidth;
+            _boxCollider.size = new Vector2(1f - _skinWidth, 1f - _skinWidth);
+            if (!Application.IsPlaying(this))
+            {
+                return;
+            }
+
+            if (_hitBuffer == null || _preallocatedHitBufferSize != _hitBuffer.Length)
+            {
+                _hitBuffer = new RaycastHit2D[_preallocatedHitBufferSize];
+            }
+        }
+
+        void OnDrawGizmos()
+        {
+            // draw a bounding box that should be identical to the BoxCollider2D bounds in the editor window,
+            // surrounded by an outer bounding box offset by our skin with, with a pair of arrows from the that
+            // should be identical to the transform's axes in the editor window
+            Bounds box = Bounds;
+            Vector2 center    = new(box.center.x, box.center.y);
+            Vector2 skinRatio = new(1f + (_skinWidth / box.extents.x), 1f + (_skinWidth / box.extents.y));
+            Vector2 xAxis     = box.extents.x * Forward;
+            Vector2 yAxis     = box.extents.y * Up;
+
+            GizmoExtensions.DrawRect(center, xAxis, yAxis, Color.black);
+            GizmoExtensions.DrawRect(center, skinRatio.x * xAxis, skinRatio.y * yAxis, Color.black);
+            GizmoExtensions.DrawArrow(from: center, to: center + xAxis, color: Color.red);
+            GizmoExtensions.DrawArrow(from: center, to: center + yAxis, color: Color.green);
+        }
+        #endif
+    }
+}

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
@@ -10,7 +10,7 @@ namespace PQ._Experimental.Overlap_001
         [SerializeField] private BoxCollider2D _boxCollider;
 
         [SerializeField] private LayerMask _layerMask = default;
-        [SerializeField] [Range(0,   1)] private float _skinWidth = 0.01f;
+        [SerializeField] [Range(0,   1)] private float _skinWidth = 0.075f;
         [SerializeField] [Range(1, 100)] private int _preallocatedHitBufferSize = 16;
 
         private ContactFilter2D _contactFilter;

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
@@ -61,16 +61,6 @@ namespace PQ._Experimental.Overlap_001
             _contactFilter.SetLayerMask(_layerMask);
         }
 
-
-        /* Immediately set facing of horizontal/vertical axes. */
-        public void Flip(bool horizontal, bool vertical)
-        {
-            _rigidbody.transform.localEulerAngles = new Vector3(
-                x: vertical   ? 180f : 0f,
-                y: horizontal ? 180f : 0f,
-                z: 0f);
-        }
-
         /* Immediately move body by given amount. */
         public void MoveBy(Vector2 delta)
         {
@@ -111,40 +101,6 @@ namespace PQ._Experimental.Overlap_001
             return !hits.IsEmpty;
         }
         
-        
-        /*
-        Check each side for _any_ colliders occupying the region between AABB and the outer perimeter defined by skin width.
-
-        If no layermask provided, uses the one assigned in editor.
-        */
-        public CollisionFlags2D CheckSides()
-        {
-            _contactFilter.useNormalAngle = true;
-            bool isFlippedHorizontal = _rigidbody.transform.localEulerAngles.y >= 90f;
-            bool isFlippedVertical   = _rigidbody.transform.localEulerAngles.x >= 90f;
-
-            CollisionFlags2D flags = CollisionFlags2D.None;
-            if (HasContactsInNormalRange(315, 45))
-            {
-                flags |= isFlippedHorizontal? CollisionFlags2D.Behind : CollisionFlags2D.Front;
-            }
-            if (HasContactsInNormalRange(45, 135))
-            {
-                flags |= isFlippedVertical ? CollisionFlags2D.Above : CollisionFlags2D.Below;
-            }
-            if (HasContactsInNormalRange(135, 225))
-            {
-                flags |= isFlippedHorizontal ? CollisionFlags2D.Front : CollisionFlags2D.Behind;
-            }
-            if (HasContactsInNormalRange(225, 315))
-            {
-                flags |= isFlippedVertical ? CollisionFlags2D.Below : CollisionFlags2D.Above;
-            }
-            _contactFilter.useNormalAngle = false;
-            Debug.Log(flags);
-            return flags;
-        }
-
         
         /* Compute distance from center to edge of our bounding box in given direction. */
         public float ComputeDistanceToEdge(Vector2 direction)

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs.meta
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ef1ee07f05914143bd0c32e36b8ced6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
@@ -1,19 +1,21 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
+
 namespace PQ._Experimental.Overlap_001
 {
     public class Character : MonoBehaviour
     {
-        private Mover _mover;
-        private Vector2? _requestedPosition;
+        [SerializeField] private Mover _mover;
 
+        private Vector2? _requestedPosition;
+        private bool _overlapResolveRequested;
         
-        void Awake()
+        void Start()
         {
             Application.targetFrameRate = 60;
-            _mover = new Mover(gameObject.transform);
             _requestedPosition = null;
+            _overlapResolveRequested = false;
         }
 
         void Update()
@@ -21,11 +23,15 @@ namespace PQ._Experimental.Overlap_001
             if (!_requestedPosition.HasValue && Mouse.current.leftButton.wasPressedThisFrame)
             {
                 _requestedPosition = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
-                Debug.Log(_requestedPosition);
             }
             else
             {
                 _requestedPosition = null;
+            }
+
+            if (Keyboard.current[Key.Space].isPressed)
+            {
+                _overlapResolveRequested = true;
             }
         }
 
@@ -34,6 +40,10 @@ namespace PQ._Experimental.Overlap_001
             if (_requestedPosition.HasValue)
             {
                 _mover.MoveTo(_requestedPosition.Value);
+            }
+            if (_overlapResolveRequested)
+            {
+                _mover.ResolveOverlapInLastDirectionMoved();
             }
         }
     }

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+
+namespace PQ._Experimental.Overlap_001
+{
+    public class Character : MonoBehaviour
+    {
+        [Range(0, 10)] [SerializeField] private float _timeScale         = 1f;
+        [Range(0, 10)] [SerializeField] private float _horizontalSpeed   = 5f;
+        [Range(0, 50)] [SerializeField] private float _gravitySpeed      = 10f;
+        [Range(0, 50)] [SerializeField] private int   _maxMoveIterations = 10;
+
+        private bool    _grounded  = true;
+        private Vector2 _inputAxis = Vector2.zero;
+        private Mover   _mover;
+
+        public override string ToString() =>
+            $"Character{{" +
+                $"horizontalSpeed:{_horizontalSpeed}," +
+                $"gravitySpeed:{_gravitySpeed}," +
+                $"maxMoveIterations:{_maxMoveIterations}," +
+            $"}}";
+
+        
+        void Awake()
+        {
+            // set fps to 60 for more determinism when testing movement
+            Application.targetFrameRate = 60;
+
+            _mover = new Mover(gameObject.transform);
+        }
+
+        void Update()
+        {
+            _inputAxis = new(
+                x: (Keyboard.current[Key.A].isPressed ? -1f : 0f) + (Keyboard.current[Key.D].isPressed ? 1f : 0f),
+                y: (Keyboard.current[Key.S].isPressed ? -1f : 0f) + (Keyboard.current[Key.W].isPressed ? 1f : 0f)
+            );
+
+            _mover.SetParams(_maxMoveIterations);
+            Time.timeScale = _timeScale;
+        }
+
+        void FixedUpdate()
+        {
+            if (!Mathf.Approximately(_inputAxis.x, 0f))
+            {
+                _mover.Flip(horizontal: _inputAxis.x < 0);
+            }
+
+            float time = Time.fixedDeltaTime;
+            Vector2 velocity = new(
+                x: _inputAxis.x * _horizontalSpeed,
+                y: _grounded? 0 : -_gravitySpeed
+            );
+
+            _mover.Move(time * velocity);
+            _grounded = _mover.InContact(CollisionFlags2D.Below);
+        }
+    }
+}

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs.meta
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8ec4295c984df54193ccd1044de6e0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/GizmoExtensions.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/GizmoExtensions.cs
@@ -1,0 +1,118 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+
+namespace PQ._Experimental.Overlap_001
+{
+    /*
+    Various utilities for drawing and manipulating gizmos.
+
+    Includes resetting of color to what it was previously before the call to minimize side effects.
+    */
+    public static class GizmoExtensions
+    {
+        private static readonly Color DefaultColor = Color.white;
+
+        /* Draw text at given world position. */
+        public static void DrawText(Vector2 position, string text, Color? color = null)
+        {
+            // since handles are only available in editor, this becomes a no op when running elsewhere
+            #if UNITY_EDITOR
+            Color previousColor = Handles.color;
+            Handles.color = color.GetValueOrDefault(DefaultColor);
+
+            Handles.Label(position, text);
+
+            Handles.color = previousColor;
+            #endif
+        }
+
+        /* Draw line between given world positions. */
+        public static void DrawLine((Vector2, Vector2) endpoints, Color? color = null)
+        {
+            Color previousColor = Gizmos.color;
+            Gizmos.color = color.GetValueOrDefault(DefaultColor);
+
+            Gizmos.DrawLine(endpoints.Item1, endpoints.Item2);
+
+            Gizmos.color = previousColor;
+        }
+
+        /* Draw sides of rectangle corresponding to the area represented by given relative origin and axes. */
+        public static void DrawRect(Vector2 origin, Vector2 xAxis, Vector2 yAxis, Color? color = null)
+        {
+            Color previousColor = Gizmos.color;
+            Gizmos.color = color.GetValueOrDefault(DefaultColor);
+
+            Vector2 min = origin - xAxis - yAxis;
+            Vector2 max = origin + xAxis + yAxis;
+            Vector2 leftBottom  = new(min.x, min.y);
+            Vector2 leftTop     = new(min.x, max.y);
+            Vector2 rightBottom = new(max.x, min.y);
+            Vector2 rightTop    = new(max.x, max.y);
+
+            Gizmos.DrawLine(leftTop,     rightTop);
+            Gizmos.DrawLine(leftBottom,  rightBottom);
+            Gizmos.DrawLine(leftBottom,  leftTop);
+            Gizmos.DrawLine(rightBottom, rightTop);
+
+            Gizmos.color = previousColor;
+        }
+        
+        /* Draw lines between given points. */
+        public static void DrawWaypoints(Vector2[] points, Color? color = null)
+        {
+            if (points == null || points.Length < 2)
+            {
+                return;
+            }
+
+            Color previousColor = Gizmos.color;
+            Gizmos.color = color.GetValueOrDefault(DefaultColor);
+
+            for (int i = 1; i < points.Length; i++)
+            {
+                Gizmos.DrawLine(points[i-1], points[i]);
+            }
+
+            Gizmos.color = previousColor;
+        }
+
+        /* Draw a 3d sphere at given world position. */
+        public static void DrawSphere(Vector2 origin, float radius, Color? color = null)
+        {
+            Color previousColor = Gizmos.color;
+            Gizmos.color = color.GetValueOrDefault(DefaultColor);
+
+            Gizmos.DrawSphere(origin, radius);
+
+            Gizmos.color = previousColor;
+        }
+
+        /*
+        Assumes arrow head length is nonzero and from,to are nonequal.
+        
+        Note that arrow head length and height are configured to be the same length for simplicity,
+        and sized relative to length of line.
+        */
+        public static void DrawArrow(Vector2 from, Vector2 to, Color? color = null,
+            float arrowheadSizeRatio = 0.10f)
+        {
+            Color previousColor = Gizmos.color;
+            Gizmos.color = color.GetValueOrDefault(DefaultColor);
+
+            Vector2 vector    = to - from;
+            Vector2 dir       = vector.normalized;
+            float length      = vector.magnitude;
+            float arrowLength = arrowheadSizeRatio * length;
+            Vector2 arrowheadBottom      = from + ((length - arrowLength) * dir);
+            Vector2 arrowheadBaseExtents = new Vector2(-dir.y, dir.x) * arrowLength * 0.50f;
+
+            Gizmos.DrawLine(from, to);
+            Gizmos.DrawLine(arrowheadBottom + arrowheadBaseExtents, to);
+            Gizmos.DrawLine(arrowheadBottom - arrowheadBaseExtents, to);
+
+            Gizmos.color = previousColor;
+        }
+    }
+}

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/GizmoExtensions.cs.meta
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/GizmoExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ccdc1e24094a9e47a61a728f3347f4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
@@ -5,21 +5,9 @@ using UnityEngine;
 
 namespace PQ._Experimental.Overlap_001
 {
-    [Flags]
-    public enum CollisionFlags2D
-    {
-        None   = 0,
-        Front  = 1 << 1,
-        Below  = 1 << 2,
-        Behind = 1 << 3,
-        Above  = 1 << 4,
-        All    = ~0,
-    }
     public sealed class Mover
     {
         private Body _body;
-        private int _maxMoveIterations;
-        private CollisionFlags2D _collisions;
         
         [Pure]
         private (float distance, Vector2 direction) DecomposeDelta(Vector2 delta)
@@ -41,94 +29,12 @@ namespace PQ._Experimental.Overlap_001
         public Mover(Transform transform)
         {
             _body = transform.GetComponent<Body>();
-            _collisions = CollisionFlags2D.None;
-            _body.Flip(horizontal: false, vertical: false);
         }
 
-        public void SetParams(int maxMoveIterations)
+        public void MoveTo(Vector2 target)
         {
-            _maxMoveIterations = maxMoveIterations;
-        }
-
-        public void Flip(bool horizontal)
-        {
-            _body.Flip(horizontal, false);
-        }
-
-        /*
-        Move body given amount.
-        
-        Notes
-        - Interpolation is supported
-        - Assumes all collisions are with static (non-moving) objects
-        - For flexibility, any external movement such as gravity must be accounted for in given delta
-        - Movement is only opted-out if within floating point tolerances of zero, as anything larger will lead to
-          skipping movement when deltas are small due to the timestep/world-scale/frame-rate used to compute it prior
-        */
-        public void Move(Vector2 deltaPosition)
-        {
-            if (deltaPosition == Vector2.zero)
-            {
-                // todo: look into adding min separation resolution here for any overlapping colliders
-                _collisions = _body.CheckSides();
-                return;
-            }
-
-            // scale deltas in proportion to the y-axis
-            Vector2 up         = _body.Up;
-            Vector2 vertical   = Vector2.Dot(deltaPosition, up) * up;
-            Vector2 horizontal = deltaPosition - vertical;
-            Vector2 position   = _body.Position;
-
-            // note that we resolve horizontal first as the movement is simpler than vertical
-            MoveHorizontal(horizontal);
-            MoveVertical(vertical);
-
-            _body.MovePosition(startPositionThisFrame: position, targetPositionThisFrame: _body.Position);
-
-            _collisions = _body.CheckSides();
-        }
-
-        public bool InContact(CollisionFlags2D flags)
-        {
-            return (_collisions & flags) == flags;
-        }
-        
-
-        private void MoveHorizontal(Vector2 initialDelta)
-        {
-            (float distanceLeft, Vector2 currentDirection) = DecomposeDelta(initialDelta);
-            for (int i = 0; i < _maxMoveIterations; i++)
-            {
-                if (!MoveAABBAlongDelta(currentDirection, ref distanceLeft, out float step, out RaycastHit2D obstruction))
-                {
-                    break;
-                }
-            }
-        }
-
-        private void MoveVertical(Vector2 initialDelta)
-        {
-            (float distanceLeft, Vector2 currentDirection) = DecomposeDelta(initialDelta);
-            for (int i = 0; i < _maxMoveIterations; i++)
-            {
-                if (!MoveAABBAlongDelta(currentDirection, ref distanceLeft, out float step, out RaycastHit2D obstruction))
-                {
-                    break;
-                }
-            }
-        }
-
-        
-        /* Project AABB along delta until (if any) obstruction. Assumes no initial overlaps. Max distance caps at body-radius to prevent tunneling. */
-        private bool MoveAABBAlongDelta(Vector2 direction, ref float distanceLeft, out float step, out RaycastHit2D obstruction)
-        {
-            // todo: verify small differences, and that things don't go negative, etc
-            float distanceToAABBEdge = _body.ComputeDistanceToEdge(direction);
-
-            // move box along delta a distance no greater than bound-extents, stopping at the first collision (if any)
-            obstruction = default;
-            step = Mathf.Min(distanceToAABBEdge, distanceLeft);
+            RaycastHit2D obstruction = default;
+            (float step, Vector2 direction) = DecomposeDelta(target - _body.Position);
             if (_body.CastAABB(direction, step, out ReadOnlySpan<RaycastHit2D> hits, false))
             {
                 obstruction = hits[0];
@@ -140,19 +46,7 @@ namespace PQ._Experimental.Overlap_001
             if (obstruction && _body.ComputeDepenetration(obstruction.collider, direction, step, out float separation) && separation < 0)
             {
                 _body.MoveBy(separation * direction);
-                step -= separation;
             }
-
-            // if no step to take, there's no more that can move
-            Vector2 deltaStep = step * direction;
-            if (deltaStep == Vector2.zero)
-            {
-                step = 0f;
-                distanceLeft = 0f;
-                return false;
-            }
-            distanceLeft -= step;
-            return true;
         }
     }
 }

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Diagnostics.Contracts;
+using UnityEngine;
+
+
+namespace PQ._Experimental.Overlap_001
+{
+    [Flags]
+    public enum CollisionFlags2D
+    {
+        None   = 0,
+        Front  = 1 << 1,
+        Below  = 1 << 2,
+        Behind = 1 << 3,
+        Above  = 1 << 4,
+        All    = ~0,
+    }
+    public sealed class Mover
+    {
+        private Body _body;
+        private int _maxMoveIterations;
+        private CollisionFlags2D _collisions;
+        
+        [Pure]
+        private (float distance, Vector2 direction) DecomposeDelta(Vector2 delta)
+        {
+            // below is exactly equivalent to (delta.normalized, delta.magnitude) without the redundant
+            // sqrt call (benchmarks showed ~54% faster), and without NaNs on zero length vectors by just dividing distance
+            float squaredMagnitude = delta.sqrMagnitude;
+            if (squaredMagnitude <= 1E-010f)
+            {
+                return (0f, Vector2.zero);
+            }
+
+            float magnitude = Mathf.Sqrt(squaredMagnitude);
+            delta /= magnitude;
+            return (magnitude, delta);
+        }
+
+
+        public Mover(Transform transform)
+        {
+            _body = transform.GetComponent<Body>();
+            _collisions = CollisionFlags2D.None;
+            _body.Flip(horizontal: false, vertical: false);
+        }
+
+        public void SetParams(int maxMoveIterations)
+        {
+            _maxMoveIterations = maxMoveIterations;
+        }
+
+        public void Flip(bool horizontal)
+        {
+            _body.Flip(horizontal, false);
+        }
+
+        /*
+        Move body given amount.
+        
+        Notes
+        - Interpolation is supported
+        - Assumes all collisions are with static (non-moving) objects
+        - For flexibility, any external movement such as gravity must be accounted for in given delta
+        - Movement is only opted-out if within floating point tolerances of zero, as anything larger will lead to
+          skipping movement when deltas are small due to the timestep/world-scale/frame-rate used to compute it prior
+        */
+        public void Move(Vector2 deltaPosition)
+        {
+            if (deltaPosition == Vector2.zero)
+            {
+                // todo: look into adding min separation resolution here for any overlapping colliders
+                _collisions = _body.CheckSides();
+                return;
+            }
+
+            // scale deltas in proportion to the y-axis
+            Vector2 up         = _body.Up;
+            Vector2 vertical   = Vector2.Dot(deltaPosition, up) * up;
+            Vector2 horizontal = deltaPosition - vertical;
+            Vector2 position   = _body.Position;
+
+            // note that we resolve horizontal first as the movement is simpler than vertical
+            MoveHorizontal(horizontal);
+            MoveVertical(vertical);
+
+            _body.MovePosition(startPositionThisFrame: position, targetPositionThisFrame: _body.Position);
+
+            _collisions = _body.CheckSides();
+        }
+
+        public bool InContact(CollisionFlags2D flags)
+        {
+            return (_collisions & flags) == flags;
+        }
+        
+
+        private void MoveHorizontal(Vector2 initialDelta)
+        {
+            (float distanceLeft, Vector2 currentDirection) = DecomposeDelta(initialDelta);
+            for (int i = 0; i < _maxMoveIterations; i++)
+            {
+                if (!MoveAABBAlongDelta(currentDirection, ref distanceLeft, out float step, out RaycastHit2D obstruction))
+                {
+                    break;
+                }
+            }
+        }
+
+        private void MoveVertical(Vector2 initialDelta)
+        {
+            (float distanceLeft, Vector2 currentDirection) = DecomposeDelta(initialDelta);
+            for (int i = 0; i < _maxMoveIterations; i++)
+            {
+                if (!MoveAABBAlongDelta(currentDirection, ref distanceLeft, out float step, out RaycastHit2D obstruction))
+                {
+                    break;
+                }
+            }
+        }
+
+        
+        /* Project AABB along delta until (if any) obstruction. Assumes no initial overlaps. Max distance caps at body-radius to prevent tunneling. */
+        private bool MoveAABBAlongDelta(Vector2 direction, ref float distanceLeft, out float step, out RaycastHit2D obstruction)
+        {
+            // todo: verify small differences, and that things don't go negative, etc
+            float distanceToAABBEdge = _body.ComputeDistanceToEdge(direction);
+
+            // move box along delta a distance no greater than bound-extents, stopping at the first collision (if any)
+            obstruction = default;
+            step = Mathf.Min(distanceToAABBEdge, distanceLeft);
+            if (_body.CastAABB(direction, step, out ReadOnlySpan<RaycastHit2D> hits, false))
+            {
+                obstruction = hits[0];
+                step = hits[0].distance;
+            }
+            _body.MoveBy(step * direction);
+
+            // if there was an obstruction, apply any depenetration
+            if (obstruction && _body.ComputeDepenetration(obstruction.collider, direction, step, out float separation) && separation < 0)
+            {
+                _body.MoveBy(separation * direction);
+                step -= separation;
+            }
+
+            // if no step to take, there's no more that can move
+            Vector2 deltaStep = step * direction;
+            if (deltaStep == Vector2.zero)
+            {
+                step = 0f;
+                distanceLeft = 0f;
+                return false;
+            }
+            distanceLeft -= step;
+            return true;
+        }
+    }
+}

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs.meta
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2227ad75e5f36944a4916bba012a96e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
@@ -188,6 +188,9 @@ PrefabInstance:
       addedObject: {fileID: 1732712294}
     - targetCorrespondingSourceObject: {fileID: 5726160129927588184, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       insertIndex: -1
+      addedObject: {fileID: 1732712297}
+    - targetCorrespondingSourceObject: {fileID: 5726160129927588184, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
+      insertIndex: -1
       addedObject: {fileID: 1732712293}
   m_SourcePrefab: {fileID: 100100000, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
 --- !u!1 &1732712286 stripped
@@ -217,10 +220,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1e8bdac9fac587e458592423b4185647, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _timeScale: 1
-  _horizontalSpeed: 5
-  _gravitySpeed: 10
-  _maxMoveIterations: 10
+  _mover: {fileID: 1732712297}
 --- !u!114 &1732712294
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -240,6 +240,18 @@ MonoBehaviour:
     m_Bits: 4096
   _skinWidth: 0.075
   _preallocatedHitBufferSize: 16
+--- !u!114 &1732712297
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732712286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2227ad75e5f36944a4916bba012a96e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1965850232
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
@@ -238,7 +238,7 @@ MonoBehaviour:
   _layerMask:
     serializedVersion: 2
     m_Bits: 4096
-  _skinWidth: 0.01
+  _skinWidth: 0.075
   _preallocatedHitBufferSize: 16
 --- !u!1001 &1965850232
 PrefabInstance:

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
@@ -133,7 +133,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5726160129927588184, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_Name
-      value: BoxBoyV2
+      value: BoxBoy
       objectReference: {fileID: 0}
     - target: {fileID: 6068203031854652124, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_Size.x
@@ -197,10 +197,10 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 5726160129927588184, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1732712293}
+      addedObject: {fileID: 1732712294}
     - targetCorrespondingSourceObject: {fileID: 5726160129927588184, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 1732712294}
+      addedObject: {fileID: 1732712293}
   m_SourcePrefab: {fileID: 100100000, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
 --- !u!1 &1732712286 stripped
 GameObject:
@@ -226,16 +226,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1732712286}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 487553ab2ac03684fb04363bb8ec097a, type: 3}
+  m_Script: {fileID: 11500000, guid: 1e8bdac9fac587e458592423b4185647, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _rigidbody: {fileID: 1732712289}
-  _boxCollider: {fileID: 1732712288}
-  _layerMask:
-    serializedVersion: 2
-    m_Bits: 4096
-  _skinWidth: 0.01
-  _preallocatedHitBufferSize: 16
+  _timeScale: 1
+  _horizontalSpeed: 5
+  _gravitySpeed: 10
+  _maxMoveIterations: 10
 --- !u!114 &1732712294
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -245,13 +242,16 @@ MonoBehaviour:
   m_GameObject: {fileID: 1732712286}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a8ec4295c984df54193ccd1044de6e0b, type: 3}
+  m_Script: {fileID: 11500000, guid: 8ef1ee07f05914143bd0c32e36b8ced6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _timeScale: 1
-  _horizontalSpeed: 5
-  _gravitySpeed: 10
-  _maxMoveIterations: 10
+  _rigidbody: {fileID: 1732712289}
+  _boxCollider: {fileID: 1732712288}
+  _layerMask:
+    serializedVersion: 2
+    m_Bits: 4096
+  _skinWidth: 0.01
+  _preallocatedHitBufferSize: 16
 --- !u!1001 &1965850232
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
@@ -135,18 +135,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: BoxBoy
       objectReference: {fileID: 0}
-    - target: {fileID: 6068203031854652124, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
-      propertyPath: m_Size.x
-      value: 0.99
-      objectReference: {fileID: 0}
-    - target: {fileID: 6068203031854652124, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
-      propertyPath: m_Size.y
-      value: 0.99
-      objectReference: {fileID: 0}
-    - target: {fileID: 6068203031854652124, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
-      propertyPath: m_EdgeRadius
-      value: 0.01
-      objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_RootOrder
       value: 2

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity.meta
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0523ef3d372ee7447958b738611d13a7
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Duplicates the second movement sandbox test scene with teleport to target on mouse click interaction, with space to do the resolution, so it's easier to test in isolation.