### PR TITLE
[Physics] Test Scenes - Working overlap resolution: depenetrate along path moved

### DIFF
--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
@@ -61,6 +61,11 @@ namespace PQ._Experimental.Overlap_001
             _contactFilter.SetLayerMask(_layerMask);
         }
 
+        /* Immediately move body to given point. */
+        public void MoveTo(Vector2 position)
+        {
+            _rigidbody.position = position;
+        }
 
         /* Immediately move body by given amount. */
         public void MoveBy(Vector2 delta)

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Body.cs
@@ -31,6 +31,7 @@ namespace PQ._Experimental.Overlap_001
         public Vector2 Forward   => _rigidbody.transform.right.normalized;
         public Vector2 Up        => _rigidbody.transform.up.normalized;
         public float   SkinWidth => _skinWidth;
+        public Vector2 Extents   => _boxCollider.bounds.extents + new Vector3(_boxCollider.edgeRadius, _boxCollider.edgeRadius, 0f);
 
 
         void Awake()

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
@@ -33,6 +33,10 @@ namespace PQ._Experimental.Overlap_001
             {
                 _overlapResolveRequested = true;
             }
+            else
+            {
+                _overlapResolveRequested = false;
+            }
         }
 
         void FixedUpdate()
@@ -43,7 +47,7 @@ namespace PQ._Experimental.Overlap_001
             }
             if (_overlapResolveRequested)
             {
-                _mover.ResolveDepenetrationAlongLastMove();
+                _mover.Depenetrate(Vector2.right);
             }
         }
     }

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
@@ -43,7 +43,7 @@ namespace PQ._Experimental.Overlap_001
             }
             if (_overlapResolveRequested)
             {
-                _mover.ResolveOverlapInLastDirectionMoved();
+                _mover.ResolveDepenetrationAlongLastMove();
             }
         }
     }

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
@@ -20,7 +20,7 @@ namespace PQ._Experimental.Overlap_001
 
         void Update()
         {
-            _overlapResolveRequested = Keyboard.current[Key.Space].isPressed;
+            _overlapResolveRequested = Keyboard.current[Key.Space].wasPressedThisFrame;
             if (!_requestedPosition.HasValue && Mouse.current.leftButton.wasPressedThisFrame)
             {
                 _requestedPosition = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Character.cs
@@ -20,6 +20,7 @@ namespace PQ._Experimental.Overlap_001
 
         void Update()
         {
+            _overlapResolveRequested = Keyboard.current[Key.Space].isPressed;
             if (!_requestedPosition.HasValue && Mouse.current.leftButton.wasPressedThisFrame)
             {
                 _requestedPosition = Camera.main.ScreenToWorldPoint(Mouse.current.position.ReadValue());
@@ -27,15 +28,6 @@ namespace PQ._Experimental.Overlap_001
             else
             {
                 _requestedPosition = null;
-            }
-
-            if (Keyboard.current[Key.Space].isPressed)
-            {
-                _overlapResolveRequested = true;
-            }
-            else
-            {
-                _overlapResolveRequested = false;
             }
         }
 
@@ -47,7 +39,7 @@ namespace PQ._Experimental.Overlap_001
             }
             if (_overlapResolveRequested)
             {
-                _mover.Depenetrate(Vector2.right);
+                _mover.DepenetrateAlongLastMove();
             }
         }
     }

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
@@ -42,7 +42,7 @@ namespace PQ._Experimental.Overlap_001
 
             // if there was an obstruction, apply any depenetration
             _previousDepenetrate = (position, position);
-            if (obstruction && ComputeDepenetration(obstruction.collider, direction, maxDistance, out float separation, out Vector2 resolveNormal))
+            if (obstruction && ComputeDepenetration(obstruction.collider, direction, 2f * _body.Extents.magnitude, out float separation, out Vector2 resolveNormal))
             {
                 _body.MoveBy(separation * resolveNormal);
                 _previousDepenetrate = (position, position + separation * resolveNormal);
@@ -55,7 +55,7 @@ namespace PQ._Experimental.Overlap_001
 
         Uses separating axis theorem to determine overlap - may require more invocations for complex polygons.
         */
-        private bool ComputeDepenetration(Collider2D collider, Vector2 direction, float maxScanDistance, out float separation, out Vector2 resolveNormal)
+        private bool ComputeDepenetration(Collider2D collider, Vector2 direction, float maxDepenetrateAmount, out float separation, out Vector2 resolveNormal)
         {
             separation = 0f;
             resolveNormal = direction;
@@ -74,7 +74,7 @@ namespace PQ._Experimental.Overlap_001
 
             Vector2 pointOnAABBEdge = _minSep.pointA;
             Vector2 directionToSurface = _minSep.isOverlapped ? -direction : direction;
-            if (_body.CastRayAt(collider, pointOnAABBEdge, directionToSurface, maxScanDistance, out RaycastHit2D hit, false))
+            if (_body.CastRayAt(collider, pointOnAABBEdge, directionToSurface, maxDepenetrateAmount, out RaycastHit2D hit, false))
             {
                 separation = _minSep.isOverlapped ? -Mathf.Abs(hit.distance) : Mathf.Abs(hit.distance);
             }
@@ -82,7 +82,7 @@ namespace PQ._Experimental.Overlap_001
             {
                 throw new InvalidOperationException(
                     $"Given {collider} not found between " +
-                    $"{pointOnAABBEdge} and {pointOnAABBEdge + maxScanDistance * direction}");
+                    $"{pointOnAABBEdge} and {pointOnAABBEdge + maxDepenetrateAmount * direction}");
             }
             return (separation * direction) != Vector2.zero;
         }

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
@@ -74,13 +74,16 @@ namespace PQ._Experimental.Overlap_001
 
             Vector2 pointOnAABBEdge = _minSep.pointA;
             Vector2 directionToSurface = _minSep.isOverlapped ? -direction : direction;
+
+            Debug.DrawLine(pointOnAABBEdge, pointOnAABBEdge + maxDepenetrateAmount * directionToSurface, Color.red, 2f);
             if (_body.CastRayAt(collider, pointOnAABBEdge, directionToSurface, maxDepenetrateAmount, out RaycastHit2D hit, false))
             {
                 separation = _minSep.isOverlapped ? -Mathf.Abs(hit.distance) : Mathf.Abs(hit.distance);
+                Debug.DrawLine(pointOnAABBEdge, pointOnAABBEdge + separation * directionToSurface, Color.green, 2f);
             }
             else
             {
-                throw new InvalidOperationException(
+                throw new InvalidOperationException( 
                     $"Given {collider} not found between " +
                     $"{pointOnAABBEdge} and {pointOnAABBEdge + maxDepenetrateAmount * direction}");
             }

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
@@ -41,10 +41,13 @@ namespace PQ._Experimental.Overlap_001
         {
             _previousMove = (_body.Position, target);
             _body.MoveBy(_previousMove.to - _previousMove.from);
-            ResolveOverlapInLastDirectionMoved(false);
+
+            Vector2 position = _body.Position;
+            ResolveDepenetrationAlongLastMove();
+            _body.MoveTo(position);
         }
 
-        public void ResolveOverlapInLastDirectionMoved(bool actuallyMove = true)
+        public void ResolveDepenetrationAlongLastMove()
         {
             RaycastHit2D obstruction = default;
             (float step, Vector2 direction) = DecomposeDelta(_previousMove.to - _previousMove.from);
@@ -53,18 +56,12 @@ namespace PQ._Experimental.Overlap_001
                 obstruction = hits[0];
                 step = hits[0].distance;
             }
-            if (actuallyMove)
-            {
-                _body.MoveBy(step * direction);
-            }
+            _body.MoveBy(step * direction);
 
             // if there was an obstruction, apply any depenetration
             if (obstruction && ComputeDepenetration(obstruction.collider, direction, step, out float separation) && separation < 0)
             {
-                if (actuallyMove)
-                {
-                    _body.MoveBy(separation * direction);
-                }
+                _body.MoveBy(separation * direction);
             }
         }
         

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
@@ -27,7 +27,7 @@ namespace PQ._Experimental.Overlap_001
             _body.MoveBy(_previousMove.to - _previousMove.from);
         }
 
-        // if direction was zero, then resolve to min separation
+        // note - resolves to min separation if the last move's distance was zero
         public void DepenetrateAlongLastMove()
         {
             Vector2 direction = (_previousMove.to - _previousMove.from).normalized;

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
@@ -43,6 +43,7 @@ namespace PQ._Experimental.Overlap_001
             _previousDepenetrate = (_body.Position, _body.Position);
             if (obstruction && ComputeDepenetration(obstruction.collider, direction, maxDistance, out float separation) && separation < 0)
             {
+                Debug.Log(separation);
                 _previousDepenetrate = (_body.Position, _body.Position + separation * direction);
                 _body.MoveTo(_previousDepenetrate.after);
             }
@@ -74,7 +75,6 @@ namespace PQ._Experimental.Overlap_001
             if (_body.CastRayAt(collider, pointOnAABBEdge, directionToSurface, maxScanDistance, out RaycastHit2D hit, false))
             {
                 separation = _minSep.isOverlapped ? -Mathf.Abs(hit.distance) : Mathf.Abs(hit.distance);
-                Debug.Log(separation);
             }
             else
             {

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Mover.cs
@@ -27,7 +27,7 @@ namespace PQ._Experimental.Overlap_001
             _body.MoveBy(_previousMove.to - _previousMove.from);
         }
 
-        // note - resolves to min separation if the last move's distance was zero
+        // note - resolves to min separation if the last move distance was zero
         public void DepenetrateAlongLastMove()
         {
             Vector2 direction = (_previousMove.to - _previousMove.from).normalized;

--- a/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
+++ b/Assets/_Experimental/Sandbox_Movement/Overlap_001/Scene_OverlapSolver.unity
@@ -145,7 +145,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.5
+      value: 1.1
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z


### PR DESCRIPTION
Adds a test scene with depenetration along path moved, after teleporting boxboy via a click.

Doesn't handle multiple AABB corners penetrating, or distances greater than extents well, though.
Will either have to special case for amount of aabb corners overlapped, or switch to a capsule collider.