### PR TITLE
[Physics] Surface projection: Fix projection and visualize travel paths

### DIFF
--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/Controller.cs
@@ -36,7 +36,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
             if (_positionHistory.IsEmpty || _positionHistory.Back != currentPosition)
             {
                 _positionHistory.PushBack(_kinematicBody.Position);
-            } 
+            }
 
             if (_nextButtonPressed)
             {

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/Controller.cs
@@ -31,15 +31,16 @@ namespace PQ._Experimental.Physics.LinearStep_002
 
         void FixedUpdate()
         {
-            Vector2 position = _kinematicBody.Position;
-            if (_positionHistory.IsEmpty || _positionHistory.Back != position)
+            Vector2 currentPosition = _kinematicBody.Position;
+            Vector2 targetPosition  = _target.bounds.center;
+            if (_positionHistory.IsEmpty || _positionHistory.Back != currentPosition)
             {
                 _positionHistory.PushBack(_kinematicBody.Position);
-            } 
+            }
 
             if (_nextButtonPressed)
             {
-                _kinematicSolver.Move((Vector2)_target.bounds.center - position);
+                _kinematicSolver.Move(targetPosition - currentPosition);
             }
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/Controller.cs
@@ -36,7 +36,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
             if (_positionHistory.IsEmpty || _positionHistory.Back != currentPosition)
             {
                 _positionHistory.PushBack(_kinematicBody.Position);
-            }
+            } 
 
             if (_nextButtonPressed)
             {

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/Controller.cs
@@ -35,7 +35,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
             if (_positionHistory.IsEmpty || _positionHistory.Back != position)
             {
                 _positionHistory.PushBack(_kinematicBody.Position);
-            }
+            } 
 
             if (_nextButtonPressed)
             {

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicBody2D.cs
@@ -148,6 +148,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
             int layer = collider.gameObject.layer;
             bool queriesStartInColliders = Physics2D.queriesStartInColliders;
             LayerMask includeLayers = _contactFilter.layerMask;
+
             collider.gameObject.layer = Physics2D.IgnoreRaycastLayer;
             Physics2D.queriesStartInColliders = includeAlreadyOverlappingColliders;
             _contactFilter.SetLayerMask(~collider.gameObject.layer);
@@ -166,7 +167,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
                     hit = _hitBuffer[i];
                     break;
                 }
-            }            
+            }
             #if UNITY_EDITOR
             if (DrawRayCastsInEditor)
             {

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicBody2D.cs
@@ -184,6 +184,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
         */
         public bool CastAABB(Vector2 direction, float distance, out RaycastHit2D hit)
         {
+            Physics2D.queriesStartInColliders = false;
             if (_boxCollider.Cast(direction, _contactFilter, _hitBuffer, distance) > 0)
             {
                 hit = _hitBuffer[0];
@@ -192,6 +193,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
             {
                 hit = default;
             }
+            Physics2D.queriesStartInColliders = false;
             return hit;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicLinearSolver2D.cs
@@ -7,10 +7,11 @@ namespace PQ._Experimental.Physics.LinearStep_002
 {
     internal sealed class KinematicLinearSolver2D
     {
+        private Vector2 _surfaceNormal;
         private KinematicBody2D _body;
 
-        private float   moveDistance;
-        private Vector2 moveDirection;
+
+        // todo: cache any direction dependent data (eg body-radius, projection)
 
         public KinematicLinearSolver2D(KinematicBody2D kinematicBody2D)
         {
@@ -20,27 +21,29 @@ namespace PQ._Experimental.Physics.LinearStep_002
             }
             _body = kinematicBody2D;
 
-            moveDistance  = 0f;
-            moveDirection = Vector2.right;
+            _surfaceNormal = Vector2.up;
         }
 
         /* Project AABB along delta until (if any) obstruction. Max distance caps at body-radius to prevent tunneling. */
         public void Move(Vector2 delta)
         {
-            // todo: cache any direction dependent data (eg body-radius, projection)
-            // todo: maintain the below distance when we implement momentum
-            moveDistance = 0f;
-
-            (float distanceRemaining, Vector2 direction) = DecomposeDelta(delta);
-            float distanceToEdge = _body.ComputeDistanceToEdge(direction);
-            MoveUnobstructed(distanceRemaining, direction, distanceToEdge, out float step, out RaycastHit2D obstruction);
-
-            // todo: avoid extra project calls
-            if (obstruction)
+            if (delta == Vector2.zero)
             {
-                delta = ProjectDeltaOnToSurface(delta, obstruction);
+                return;
             }
-            (moveDistance, moveDirection) = DecomposeDelta(delta);
+
+            (float desiredDistance,   Vector2 desiredDirection  ) = DecomposeDelta(delta);
+            (float projectedDistance, Vector2 projectedDirection) = ProjectDeltaOnToSurface(delta, _surfaceNormal);
+            Debug.DrawRay(_body.Position, _body.Position + (desiredDistance   * desiredDirection),   Color.gray,  1f);
+            Debug.DrawRay(_body.Position, _body.Position + (projectedDistance * projectedDirection), Color.green, 1f);
+            MoveUnobstructed(
+                projectedDistance,
+                projectedDirection,
+                _body.ComputeDistanceToEdge(projectedDirection),
+                out float _,
+                out RaycastHit2D obstruction);
+
+            _surfaceNormal = obstruction? obstruction.normal : Vector2.up;
         }
 
 
@@ -79,18 +82,18 @@ namespace PQ._Experimental.Physics.LinearStep_002
         }
 
         [Pure]
-        private Vector2 ProjectDeltaOnToSurface(Vector2 delta, RaycastHit2D hit)
+        private (float distance, Vector2 direction) ProjectDeltaOnToSurface(Vector2 delta, Vector2 normal)
         {
             // take perpendicular of surface normal in direction of body
             Vector2 surfaceTangent = _body.IsFlippedHorizontal
-                ? new Vector2(-hit.normal.y,  hit.normal.x)
-                : new Vector2( hit.normal.y, -hit.normal.x);
+                ? new Vector2(-normal.y,  normal.x)
+                : new Vector2( normal.y, -normal.x);
 
             // vector projection of delta onto to surface tangent (2D equivelant of 3D method ProjectOnPlane())
             // assumes non-zero normal (ie given hit is valid)
             float aDotB = Vector2.Dot(delta,          surfaceTangent);
             float bDotB = Vector2.Dot(surfaceTangent, surfaceTangent);
-            return (aDotB / bDotB) * surfaceTangent;
+            return (aDotB / bDotB, surfaceTangent);
         }
     }
 }

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicLinearSolver2D.cs
@@ -89,7 +89,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
                 ? new Vector2(-normal.y,  normal.x)
                 : new Vector2( normal.y, -normal.x);
 
-            // vector projection of delta onto to surface tangent (2D equivelant of 3D method ProjectOnPlane())
+            // vector projection of delta onto to surface tangent (2D equivalent of 3D method ProjectOnPlane())
             // assumes non-zero normal (ie given hit is valid)
             float aDotB = Vector2.Dot(delta,          surfaceTangent);
             float bDotB = Vector2.Dot(surfaceTangent, surfaceTangent);

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicLinearSolver2D.cs
@@ -27,6 +27,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
         /* Project AABB along delta until (if any) obstruction. Max distance caps at body-radius to prevent tunneling. */
         public void Move(Vector2 delta)
         {
+            //Debug.Log($"delta={delta}, normal={_surfaceNormal}");
             if (delta == Vector2.zero)
             {
                 return;
@@ -34,9 +35,10 @@ namespace PQ._Experimental.Physics.LinearStep_002
 
             (float desiredDistance,   Vector2 desiredDirection  ) = DecomposeDelta(delta);
             (float projectedDistance, Vector2 projectedDirection) = ProjectDeltaOnToSurface(delta, _surfaceNormal);
+
             Debug.DrawRay(_body.Position, _body.Position + (desiredDistance   * desiredDirection),   Color.gray,  1f);
             Debug.DrawRay(_body.Position, _body.Position + (projectedDistance * projectedDirection), Color.green, 1f);
-            MoveUnobstructed(
+            MoveUnobstructed( 
                 projectedDistance,
                 projectedDirection,
                 _body.ComputeDistanceToEdge(projectedDirection),
@@ -59,6 +61,11 @@ namespace PQ._Experimental.Physics.LinearStep_002
             if (_body.CastAABB(direction, step + startOffset, out obstruction))
             {
                 step = obstruction.distance - startOffset;
+                Debug.Log($"has obstruction! name={(obstruction.collider.name == null? "<none>" : obstruction.collider.name)} step={step} maxStep={maxStep} startOffset={startOffset} direction={direction}");
+            }
+            else
+            {
+                Debug.Log($"no obstruction! name={(obstruction.collider.name == null ? "<none>" : obstruction.collider.name)} step={step} maxStep={maxStep} startOffset={startOffset} direction={direction}");
             }
 
             _body.Position += (step + startOffset) * direction;

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/KinematicLinearSolver2D.cs
@@ -11,7 +11,7 @@ namespace PQ._Experimental.Physics.LinearStep_002
         private KinematicBody2D _body;
 
 
-        // todo: cache any direction dependent data (eg body-radius, projection)
+        // todo: cache any direction dependent data if possible (eg body-radius, projection)
 
         public KinematicLinearSolver2D(KinematicBody2D kinematicBody2D)
         {
@@ -27,7 +27,6 @@ namespace PQ._Experimental.Physics.LinearStep_002
         /* Project AABB along delta until (if any) obstruction. Max distance caps at body-radius to prevent tunneling. */
         public void Move(Vector2 delta)
         {
-            //Debug.Log($"delta={delta}, normal={_surfaceNormal}");
             if (delta == Vector2.zero)
             {
                 return;

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/_LinearStep_002__SurfaceProjection.unity
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/_LinearStep_002__SurfaceProjection.unity
@@ -311,7 +311,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 373807055}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.5, y: 0.45, z: -9}
+  m_LocalPosition: {x: 5.5, y: 0, z: -9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/_LinearStep_002__SurfaceProjection.unity
+++ b/Assets/_Experimental/Sandbox_Physics/LinearStep_002__SurfaceProjection/_LinearStep_002__SurfaceProjection.unity
@@ -214,7 +214,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y


### PR DESCRIPTION
Draws rays showing original delta and projected ones, and avoids the flip flopping bug seen before due to a bug in how the last obstruction normal was used.