### PR TITLE
Solver V3 - Maintain contact offset + U-shape surface jitter fix

### DIFF
--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
@@ -59,6 +59,11 @@ namespace PQ._Experimental.Physics.Move_005
             _kinematicSolver.RemoveOverlap(collision.collider);
         }
 
+        void OnCollisionExit2D(Collision2D collision)
+        {
+            _kinematicSolver.RemoveOverlap(collision.collider);
+        }
+
         void OnCollisionStay2D(Collision2D collision)
         {
             _kinematicSolver.RemoveOverlap(collision.collider);

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
@@ -59,11 +59,6 @@ namespace PQ._Experimental.Physics.Move_005
             _kinematicSolver.RemoveOverlap(collision.collider);
         }
 
-        void OnCollisionExit2D(Collision2D collision)
-        {
-            _kinematicSolver.RemoveOverlap(collision.collider);
-        }
-
         void OnCollisionStay2D(Collision2D collision)
         {
             _kinematicSolver.RemoveOverlap(collision.collider);

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
@@ -54,8 +54,12 @@ namespace PQ._Experimental.Physics.Move_005
             _kinematicSolver.Move(deltaPosition);
         }
 
-
         void OnCollisionEnter2D(Collision2D collision)
+        {
+            _kinematicSolver.RemoveOverlap(collision.collider);
+        }
+
+        void OnCollisionExit2D(Collision2D collision)
         {
             _kinematicSolver.RemoveOverlap(collision.collider);
         }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
@@ -56,17 +56,17 @@ namespace PQ._Experimental.Physics.Move_005
 
         void OnCollisionEnter2D(Collision2D collision)
         {
-            //_kinematicSolver.RemoveOverlap(collision.collider);
+            _kinematicSolver.RemoveOverlap(collision.collider);
         }
 
         void OnCollisionExit2D(Collision2D collision)
         {
-            //_kinematicSolver.RemoveOverlap(collision.collider);
+            _kinematicSolver.RemoveOverlap(collision.collider);
         }
 
         void OnCollisionStay2D(Collision2D collision)
         {
-            //kinematicSolver.RemoveOverlap(collision.collider);
+            _kinematicSolver.RemoveOverlap(collision.collider);
         }
 
         void OnDrawGizmos()

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
@@ -56,17 +56,17 @@ namespace PQ._Experimental.Physics.Move_005
 
         void OnCollisionEnter2D(Collision2D collision)
         {
-            _kinematicSolver.RemoveOverlap(collision.collider);
+            //_kinematicSolver.RemoveOverlap(collision.collider);
         }
 
         void OnCollisionExit2D(Collision2D collision)
         {
-            _kinematicSolver.RemoveOverlap(collision.collider);
+            //_kinematicSolver.RemoveOverlap(collision.collider);
         }
 
         void OnCollisionStay2D(Collision2D collision)
         {
-            _kinematicSolver.RemoveOverlap(collision.collider);
+            //_kinematicSolver.RemoveOverlap(collision.collider);
         }
 
         void OnDrawGizmos()

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/Controller.cs
@@ -66,7 +66,7 @@ namespace PQ._Experimental.Physics.Move_005
 
         void OnCollisionStay2D(Collision2D collision)
         {
-            //_kinematicSolver.RemoveOverlap(collision.collider);
+            //kinematicSolver.RemoveOverlap(collision.collider);
         }
 
         void OnDrawGizmos()

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
@@ -137,6 +137,24 @@ namespace PQ._Experimental.Physics.Move_005
         }
 
         /*
+        Project point along given delta from given origin, and outputs ALL hits (if any).
+
+        Note that casts ignore body's bounds, and all Physics2D cast results are sorted by ascending distance.
+        */
+        public bool CastRay(Vector2 origin, Vector2 direction, float distance, out ReadOnlySpan<RaycastHit2D> hits)
+        {
+            int layer = _transform.gameObject.layer;
+            _transform.gameObject.layer = Physics2D.IgnoreRaycastLayer;
+
+            int hitCount = Physics2D.Raycast(origin, direction, _contactFilter, _hitBuffer, distance);
+
+            _transform.gameObject.layer = layer;
+
+            hits = _hitBuffer.AsSpan(0, hitCount);
+            return hitCount > 0;
+        }
+
+        /*
         Compute distance from center to edge of our bounding box in given direction.
         */
         public float ComputeDistanceToEdge(Vector2 direction)

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
@@ -129,19 +129,11 @@ namespace PQ._Experimental.Physics.Move_005
 
         Note that casts ignore body's bounds, and all Physics2D cast results are sorted by ascending distance.
         */
-        public bool CastAABB(Vector2 direction, float distance, out RaycastHit2D hit)
+        public bool CastAABB(Vector2 direction, float distance, out ReadOnlySpan<RaycastHit2D> hits)
         {
-            Physics2D.queriesStartInColliders = false;
-            if (_boxCollider.Cast(direction, _contactFilter, _hitBuffer, distance) > 0)
-            {
-                hit = _hitBuffer[0];
-            }
-            else
-            {
-                hit = default;
-            }
-            Physics2D.queriesStartInColliders = false;
-            return hit;
+            int hitCount = _boxCollider.Cast(direction, _contactFilter, _hitBuffer, distance);
+            hits = _hitBuffer.AsSpan(0, hitCount);
+            return hitCount > 0;
         }
 
         

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
@@ -151,6 +151,12 @@ namespace PQ._Experimental.Physics.Move_005
             _transform.gameObject.layer = layer;
 
             hits = _hitBuffer.AsSpan(0, hitCount);
+
+            Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
+            if (hitCount > 0)
+            {
+                Debug.DrawLine(origin, hits[0].point, Color.green, 1f);
+            }
             return hitCount > 0;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
@@ -85,11 +85,11 @@ namespace PQ._Experimental.Physics.Move_005
             _rigidbody.constraints = RigidbodyConstraints2D.None;
         }
 
+        /* Check if body is filtering out collisions with given object or not. */
         public bool IsFilteringLayerMask(GameObject other)
         {
             return _contactFilter.IsFilteringLayerMask(other);
         }
-
 
         /*
         Use separating axis theorem to determine distance needed for no overlap.
@@ -134,41 +134,6 @@ namespace PQ._Experimental.Physics.Move_005
             int hitCount = _boxCollider.Cast(direction, _contactFilter, _hitBuffer, distance);
             hits = _hitBuffer.AsSpan(0, hitCount);
             return hitCount > 0;
-        }
-
-        
-        /*
-        Project a point along given direction until specific given collider is hit.
-
-        Note that in 3D we have collider.RayCast for this, but in 2D we have no built in way of checking a
-        specific collider (collider2D.RayCast confusingly casts _from_ it instead of _at_ it).
-        */
-        public bool CastRayAt(Collider2D collider, Vector2 origin, Vector2 direction, float distance, out RaycastHit2D hit)
-        {
-            int layer = collider.gameObject.layer;
-            bool queriesStartInColliders = Physics2D.queriesStartInColliders;
-            LayerMask includeLayers = _contactFilter.layerMask;
-
-            collider.gameObject.layer = Physics2D.IgnoreRaycastLayer;
-            Physics2D.queriesStartInColliders = true;
-            _contactFilter.SetLayerMask(~collider.gameObject.layer);
-
-            int hitCount = Physics2D.Raycast(origin, direction, _contactFilter, _hitBuffer, distance);
-
-            collider.gameObject.layer = layer;
-            _contactFilter.SetLayerMask(includeLayers);
-            Physics2D.queriesStartInColliders = queriesStartInColliders;
-
-            hit = default;
-            for (int i = 0; i < hitCount; i++)
-            {
-                if (_hitBuffer[i].collider == collider)
-                {
-                    hit = _hitBuffer[i];
-                    break;
-                }
-            }
-            return hit;
         }
 
         /*

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicBody2D.cs
@@ -129,11 +129,17 @@ namespace PQ._Experimental.Physics.Move_005
 
         Note that casts ignore body's bounds, and all Physics2D cast results are sorted by ascending distance.
         */
-        public bool CastAABB(Vector2 direction, float distance, out ReadOnlySpan<RaycastHit2D> hits)
+        public bool CastAABB(Vector2 direction, float distance, out RaycastHit2D hit)
         {
-            int hitCount = _boxCollider.Cast(direction, _contactFilter, _hitBuffer, distance);
-            hits = _hitBuffer.AsSpan(0, hitCount);
-            return hitCount > 0;
+            if (_boxCollider.Cast(direction, _contactFilter, _hitBuffer, distance) > 0)
+            {
+                hit = _hitBuffer[0];
+            }
+            else
+            {
+                hit = default;
+            }
+            return hit;
         }
 
         /*
@@ -141,23 +147,24 @@ namespace PQ._Experimental.Physics.Move_005
 
         Note that casts ignore body's bounds, and all Physics2D cast results are sorted by ascending distance.
         */
-        public bool CastRay(Vector2 origin, Vector2 direction, float distance, out ReadOnlySpan<RaycastHit2D> hits)
+        public bool CastRay(Vector2 origin, Vector2 direction, float distance, out RaycastHit2D hit)
         {
             int layer = _transform.gameObject.layer;
             _transform.gameObject.layer = Physics2D.IgnoreRaycastLayer;
 
-            int hitCount = Physics2D.Raycast(origin, direction, _contactFilter, _hitBuffer, distance);
+            Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
+            if (Physics2D.Raycast(origin, direction, _contactFilter, _hitBuffer, distance) > 0)
+            {
+                hit = _hitBuffer[0];
+                Debug.DrawLine(origin, hit.point, Color.green, 1f);
+            }
+            else
+            {
+                hit = default;
+            }
 
             _transform.gameObject.layer = layer;
-
-            hits = _hitBuffer.AsSpan(0, hitCount);
-
-            Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
-            if (hitCount > 0)
-            {
-                Debug.DrawLine(origin, hits[0].point, Color.green, 1f);
-            }
-            return hitCount > 0;
+            return hit;
         }
 
         /*

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -111,8 +111,8 @@ namespace PQ._Experimental.Physics.Move_005
                 Debug.Log($"Move({delta}).substep#{MaxMoveIterations-iteration} : " +
                           $"remaining={distanceRemaining}, direction={direction}");
                 MoveUnobstructed(
-                    distanceRemaining,
                     direction,
+                    distanceRemaining,
                     out float step,
                     out RaycastHit2D obstruction);
 
@@ -128,7 +128,7 @@ namespace PQ._Experimental.Physics.Move_005
 
 
         /* Project body along delta until (if any) obstruction. Distance swept is capped at body-radius to prevent tunneling. */
-        private void MoveUnobstructed(float distance, Vector2 direction, out float step, out RaycastHit2D obstruction)
+        private void MoveUnobstructed(Vector2 direction, float distance, out float step, out RaycastHit2D obstruction)
         {
             float bodyRadius = _body.ComputeDistanceToEdge(direction);
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -7,6 +7,7 @@ namespace PQ._Experimental.Physics.Move_005
     internal sealed class KinematicLinearSolver2D
     {
         private KinematicBody2D _body;
+        private int _lastIterationsUsed;
 
         /* Number of iterations used to reach movement target before giving up. */
         private const int MaxIterations = 10;
@@ -17,6 +18,8 @@ namespace PQ._Experimental.Physics.Move_005
         /* Amount used to ensure we don't get _too_ close to surfaces, to avoid getting stuck when moving tangential to a surface. */
         private const float ContactOffset = 0.05f;
 
+        public int IterationsUsed => _lastIterationsUsed;
+
         public KinematicLinearSolver2D(KinematicBody2D kinematicBody2D)
         {
             if (kinematicBody2D == null)
@@ -24,6 +27,7 @@ namespace PQ._Experimental.Physics.Move_005
                 throw new ArgumentNullException($"Expected non-null {nameof(KinematicLinearSolver2D)}");
             }
             _body = kinematicBody2D;
+            _lastIterationsUsed = 0;
         }
 
         public void Flip(bool horizontal, bool vertical)
@@ -109,7 +113,6 @@ namespace PQ._Experimental.Physics.Move_005
                     out RaycastHit2D obstruction);
 
                 Vector2 afterStep = _body.Position;
-
                 Debug.DrawLine(beforeStep, afterStep, Color.green, 1f);
 
                 direction -= obstruction.normal * Vector2.Dot(direction, obstruction.normal);
@@ -118,8 +121,8 @@ namespace PQ._Experimental.Physics.Move_005
 
             Vector2 endPosition = _body.Position;
 
+            _lastIterationsUsed = MaxIterations - iteration;
             _body.MovePositionWithoutBreakingInterpolation(startPosition, endPosition);
-
         }
 
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -136,11 +136,15 @@ namespace PQ._Experimental.Physics.Move_005
                 obstruction = hits[0];
                 float distancePastOffset = obstruction.distance - ContactOffset;
                 step = distancePastOffset < Epsilon? 0f : distancePastOffset;
+                
+                Debug.Log($"point={obstruction.point}");
             }
             else
             {
                 obstruction = default;
             }
+
+            Debug.Log($"hitCount={hits.Length}");
 
             _body.Position += step * direction;
         }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -177,7 +177,7 @@ namespace PQ._Experimental.Physics.Move_005
             RaycastHit2D leftHit   = leftHits[0];
             RaycastHit2D middleHit = middleHits[0];
             RaycastHit2D rightHit  = rightHits[0];
-            return middleHit.distance < leftHit.distance && middleHit.distance < rightHit.distance;
+            return middleHit.distance > leftHit.distance && middleHit.distance > rightHit.distance;
         }
     }
 }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -4,6 +4,13 @@ using UnityEngine;
 
 namespace PQ._Experimental.Physics.Move_005
 {
+    /*
+    Collide and slide solver for movement.
+
+    Notes
+    - When moving along surfaces, we maintain a slight offset from the normal, such that contacts are
+      intentionally avoided. This way, we avoid getting caught on edges and corners as easily      
+    */
     internal sealed class KinematicLinearSolver2D
     {
         private KinematicBody2D _body;

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -56,20 +56,28 @@ namespace PQ._Experimental.Physics.Move_005
                 return false;
             }
 
-            ColliderDistance2D minimumSeparation = _body.ComputeMinimumSeparation(collider);
-
-            bool overlapped = minimumSeparation.isOverlapped;
-            Vector2 offset = minimumSeparation.distance * minimumSeparation.normal;
-
-            Debug.Log($"RemoveOverlap({collider.name}) : overlapped={overlapped} offset={offset}");
-            Debug.DrawLine(_body.Position, _body.Position + offset, overlapped ? Color.green : Color.red, 1f);
-
-            if (!overlapped)
+            ColliderDistance2D initialSeparation = _body.ComputeMinimumSeparation(collider);
+            if (!initialSeparation.isOverlapped)
             {
                 return false;
             }
 
-            _body.Position += offset;
+            Vector2 startPosition = _body.Position;
+
+            int iteration = MaxIterations;
+            Vector2 offset = initialSeparation.distance * initialSeparation.normal;
+            while (iteration-- > 0 && offset != Vector2.zero)
+            {
+                offset = initialSeparation.distance * initialSeparation.normal;
+
+                _body.Position += offset;
+            }
+
+            Vector2 endPosition = _body.Position;
+
+            Debug.Log($"RemoveOverlap({collider.name}) : overlapAmount={-initialSeparation.distance}");
+            Debug.DrawLine(startPosition, endPosition, Color.blue, 1f);
+
             return true;
         }
 
@@ -92,9 +100,6 @@ namespace PQ._Experimental.Physics.Move_005
             while (iteration-- > 0 && distanceRemaining > Epsilon && direction.sqrMagnitude > Epsilon)
             {
                 Vector2 beforeStep = _body.Position;
-
-                Debug.Log($"Move({delta}).substep#{MaxIterations-iteration} : " +
-                          $"remaining={distanceRemaining}, direction={direction}");
                 Debug.DrawLine(beforeStep, beforeStep + (distanceRemaining * direction), Color.gray, 1f);
 
                 MoveUnobstructed(
@@ -114,6 +119,7 @@ namespace PQ._Experimental.Physics.Move_005
             Vector2 endPosition = _body.Position;
 
             _body.MovePositionWithoutBreakingInterpolation(startPosition, endPosition);
+
         }
 
 
@@ -129,7 +135,6 @@ namespace PQ._Experimental.Physics.Move_005
                 step = distancePastOffset < Epsilon? 0f : distancePastOffset;
             }
 
-            Debug.Log($"step={step}");
             _body.Position += step * direction;
         }
     }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -64,7 +64,7 @@ namespace PQ._Experimental.Physics.Move_005
             Debug.Log($"RemoveOverlap({collider.name}) : overlapped={overlapped} offset={offset}");
             Debug.DrawLine(_body.Position, _body.Position + offset, overlapped ? Color.green : Color.red, 1f);
 
-            if (!minimumSeparation.isOverlapped)
+            if (!overlapped)
             {
                 return false;
             }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -77,6 +77,8 @@ namespace PQ._Experimental.Physics.Move_005
         /* Project AABB along delta until (if any) obstruction. Max distance caps at body-radius to prevent tunneling. */
         public void Move(Vector2 delta)
         {
+            // note that we compare extremely close to zero rather than our larger epsilon,
+            // as delta can be very small depending on the physics step duration used to compute it
             if (delta == Vector2.zero)
             {
                 return;

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -64,17 +64,15 @@ namespace PQ._Experimental.Physics.Move_005
             Debug.Log($"RemoveOverlap({collider.name}) : overlapped={overlapped} offset={offset}");
             Debug.DrawLine(_body.Position, _body.Position + offset, overlapped ? Color.green : Color.red, 1f);
 
-            if (!overlapped)
+            if (!minimumSeparation.isOverlapped)
             {
                 return false;
             }
 
-            if (minimumSeparation.distance < Epsilon)
-            {
-                _body.Position += offset;
-            }
+            _body.Position += offset;
             return true;
         }
+
 
         /* Project AABB along delta until (if any) obstruction. Max distance caps at body-radius to prevent tunneling. */
         public void Move(Vector2 delta)
@@ -123,14 +121,13 @@ namespace PQ._Experimental.Physics.Move_005
             // slightly bias the start position such that box casts still resolve
             // even when AABB is touching a collider in that 
             float bodyRadius = _body.ComputeDistanceToEdge(direction);
-            _body.Position -= Epsilon * direction;
 
             step = distance < bodyRadius ? distance : bodyRadius;
-            if (_body.CastAABB(direction, step + Epsilon, out obstruction))
+            if (_body.CastAABB(direction, step + ContactOffset, out obstruction))
             {
                 step = obstruction.distance - ContactOffset;
             }
-            _body.Position += (step + Epsilon) * direction;
+            _body.Position += (step) * direction;
         }
     }
 }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -59,23 +59,20 @@ namespace PQ._Experimental.Physics.Move_005
             {
                 return;
             }
-
+            
             // note that we remove separation if ever so slightly above surface as well
             Vector2 startPosition = _body.Position;
-
             int iteration = MaxOverlapIterations;
             ColliderDistance2D separation = _body.ComputeMinimumSeparation(collider);
-            while (iteration-- > 0 && separation.distance < -Epsilon)
+            while (iteration-- > 0 && separation.distance < Epsilon)
             {
                 Vector2 beforeStep = _body.Position;
-                Debug.Log($"RemoveOverlap({collider.name}).substep#{MaxOverlapIterations-iteration} : " +
+                Debug.Log($"RemoveOverlap({collider.name}).substep#{MaxOverlapIterations - iteration} : " +
                           $"remaining={separation.distance}, direction={separation.normal}");
                 _body.Position += separation.distance * separation.normal;
 
                 Vector2 afterStep = _body.Position;
                 Debug.DrawLine(beforeStep, afterStep, Color.yellow, 1f);
-
-                separation = _body.ComputeMinimumSeparation(collider);
             }
             Vector2 endPosition = _body.Position;
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -133,20 +133,16 @@ namespace PQ._Experimental.Physics.Move_005
             float bodyRadius = _body.ComputeDistanceToEdge(direction);
 
             step = distance < bodyRadius ? distance : bodyRadius;
-            if (_body.CastAABB(direction, step + ContactOffset, out var hits))
+            if (_body.CastAABB(direction, step + ContactOffset, out var hit))
             {
-                obstruction = hits[0];
-                float distancePastOffset = obstruction.distance - ContactOffset;
+                float distancePastOffset = hit.distance - ContactOffset;
                 step = distancePastOffset < Epsilon? 0f : distancePastOffset;
-                
-                Debug.Log($"point={obstruction.point}");
+                obstruction = hit;
             }
             else
             {
                 obstruction = default;
             }
-
-            Debug.Log($"hitCount={hits.Length}");
 
             _body.Position += step * direction;
         }
@@ -157,26 +153,24 @@ namespace PQ._Experimental.Physics.Move_005
             Vector2 extents = _body.Extents;
 
             Vector2 bottomCenter = new Vector2(center.x, center.y - extents.y);
-            if (!_body.CastRay(bottomCenter, Vector2.down, Mathf.Infinity, out var middleHits))
+            if (!_body.CastRay(bottomCenter, Vector2.down, Mathf.Infinity, out var middleHit))
             {
                 return false;
             }
 
             Vector2 bottomLeft = new Vector2(center.x - extents.x, center.y - extents.y);
-            if (!_body.CastRay(bottomLeft, Vector2.down, Mathf.Infinity, out var leftHits))
+            if (!_body.CastRay(bottomLeft, Vector2.down, Mathf.Infinity, out var leftHit))
             {
                 return false;
             }
 
             Vector2 bottomRight = new Vector2(center.x + extents.x, center.y - extents.y);
-            if (!_body.CastRay(bottomRight, Vector2.down, Mathf.Infinity, out var rightHits))
+            if (!_body.CastRay(bottomRight, Vector2.down, Mathf.Infinity, out var rightHit))
             {
                 return false;
             }
 
-            RaycastHit2D leftHit   = leftHits[0];
-            RaycastHit2D middleHit = middleHits[0];
-            RaycastHit2D rightHit  = rightHits[0];
+            Debug.Log($"leftDist={leftHit.distance} middleDist={middleHit.distance} rightDist={rightHit.distance}");
             return middleHit.distance > leftHit.distance && middleHit.distance > rightHit.distance;
         }
     }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -118,16 +118,17 @@ namespace PQ._Experimental.Physics.Move_005
         /* Project body along delta until (if any) obstruction. Distance swept is capped at body-radius to prevent tunneling. */
         private void MoveUnobstructed(float distance, Vector2 direction, out float step, out RaycastHit2D obstruction)
         {
-            // slightly bias the start position such that box casts still resolve
-            // even when AABB is touching a collider in that 
             float bodyRadius = _body.ComputeDistanceToEdge(direction);
 
             step = distance < bodyRadius ? distance : bodyRadius;
             if (_body.CastAABB(direction, step + ContactOffset, out obstruction))
             {
-                step = obstruction.distance - ContactOffset;
+                float distancePastOffset = obstruction.distance - ContactOffset;
+                step = distancePastOffset < Epsilon? 0f : distancePastOffset;
             }
-            _body.Position += (step) * direction;
+
+            Debug.Log($"step={step}");
+            _body.Position += step * direction;
         }
     }
 }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -173,5 +173,32 @@ namespace PQ._Experimental.Physics.Move_005
             Debug.Log($"leftDist={leftHit.distance} middleDist={middleHit.distance} rightDist={rightHit.distance}");
             return middleHit.distance > leftHit.distance && middleHit.distance > rightHit.distance;
         }
+        
+        private bool CheckForConcaveFaceAlongPath(Vector2 direction, float distance)
+        {
+            Vector2 center  = _body.Center;
+            Vector2 extents = _body.Extents;
+
+            Vector2 bottomCenter = new Vector2(center.x, center.y - extents.y);
+            if (!_body.CastRay(bottomCenter, direction, distance, out var middleHit))
+            {
+                return false;
+            }
+
+            Vector2 bottomLeft = new Vector2(center.x - extents.x, center.y - extents.y);
+            if (!_body.CastRay(bottomLeft, direction, middleHit.distance, out var leftHit))
+            {
+                return false;
+            }
+
+            Vector2 bottomRight = new Vector2(center.x + extents.x, center.y - extents.y);
+            if (!_body.CastRay(bottomRight, direction, middleHit.distance, out var rightHit))
+            {
+                return false;
+            }
+
+            Debug.Log($"leftDist={leftHit.distance} middleDist={middleHit.distance} rightDist={rightHit.distance}");
+            return middleHit.distance > leftHit.distance && middleHit.distance > rightHit.distance;
+        }
     }
 }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -90,6 +90,8 @@ namespace PQ._Experimental.Physics.Move_005
         /* Project AABB along delta until (if any) obstruction. Max distance caps at body-radius to prevent tunneling. */
         public void Move(Vector2 delta)
         {
+            Debug.Log($"{(CheckForConcaveFaceBelow()?"yes":"no")}");
+
             // note that we compare extremely close to zero rather than our larger epsilon,
             // as delta can be very small depending on the physics step duration used to compute it
             if (delta == Vector2.zero)
@@ -147,6 +149,35 @@ namespace PQ._Experimental.Physics.Move_005
             Debug.Log($"hitCount={hits.Length}");
 
             _body.Position += step * direction;
+        }
+
+        private bool CheckForConcaveFaceBelow()
+        {
+            Vector2 center  = _body.Center;
+            Vector2 extents = _body.Extents;
+
+            Vector2 bottomCenter = new Vector2(center.x, center.y - extents.y);
+            if (!_body.CastRay(bottomCenter, Vector2.down, Mathf.Infinity, out var middleHits))
+            {
+                return false;
+            }
+
+            Vector2 bottomLeft = new Vector2(center.x - extents.x, center.y - extents.y);
+            if (!_body.CastRay(bottomLeft, Vector2.down, Mathf.Infinity, out var leftHits))
+            {
+                return false;
+            }
+
+            Vector2 bottomRight = new Vector2(center.x + extents.x, center.y - extents.y);
+            if (!_body.CastRay(bottomRight, Vector2.down, Mathf.Infinity, out var rightHits))
+            {
+                return false;
+            }
+
+            RaycastHit2D leftHit   = leftHits[0];
+            RaycastHit2D middleHit = middleHits[0];
+            RaycastHit2D rightHit  = rightHits[0];
+            return middleHit.distance < leftHit.distance && middleHit.distance < rightHit.distance;
         }
     }
 }

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -7,7 +7,6 @@ namespace PQ._Experimental.Physics.Move_005
     internal sealed class KinematicLinearSolver2D
     {
         private KinematicBody2D _body;
-        private int _lastIterationsUsed;
 
         /* Number of iterations used to reach movement target before giving up. */
         private const int MaxMoveIterations = 10;
@@ -56,11 +55,11 @@ namespace PQ._Experimental.Physics.Move_005
         In practice, this is not an issue except when spawning, as any movement in the solver caps changes in position be no
         greater than the body extents.
         */
-        public bool RemoveOverlap(Collider2D collider)
+        public void RemoveOverlap(Collider2D collider)
         {
             if (_body.IsFilteringLayerMask(collider.gameObject))
             {
-                return false;
+                return;
             }
 
             // note that we remove separation if ever so slightly above surface as well
@@ -84,9 +83,6 @@ namespace PQ._Experimental.Physics.Move_005
 
             // bias the resolved position ever so slightly along the normal to prevent contact
             _body.Position += Epsilon * (endPosition - startPosition).normalized;
-
-            _lastIterationsUsed = MaxOverlapIterations - iteration;
-            return true;
         }
 
 
@@ -124,8 +120,6 @@ namespace PQ._Experimental.Physics.Move_005
                 distanceRemaining -= step;
             }
             Vector2 endPosition = _body.Position;
-
-            _lastIterationsUsed = MaxMoveIterations - iteration;
             _body.MovePositionWithoutBreakingInterpolation(startPosition, endPosition);
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -20,7 +20,6 @@ namespace PQ._Experimental.Physics.Move_005
         /* Amount used to ensure we don't get _too_ close to surfaces, to avoid getting stuck when moving tangential to a surface. */
         private const float ContactOffset = 0.05f;
 
-        public int IterationsUsed => _lastIterationsUsed;
 
         public KinematicLinearSolver2D(KinematicBody2D kinematicBody2D)
         {
@@ -29,7 +28,6 @@ namespace PQ._Experimental.Physics.Move_005
                 throw new ArgumentNullException($"Expected non-null {nameof(KinematicLinearSolver2D)}");
             }
             _body = kinematicBody2D;
-            _lastIterationsUsed = 0;
         }
 
         public void Flip(bool horizontal, bool vertical)

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -46,7 +46,6 @@ namespace PQ._Experimental.Physics.Move_005
         /*
         Note that with edge colliders, the collider will end up on either side, as there is no 'internal area'.
 
-
         This means that if our body starts in more overlapped position than separated from an edge collider, it will
         resolve to the 'inside' of the edge.
         

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/KinematicLinearSolver2D.cs
@@ -124,10 +124,15 @@ namespace PQ._Experimental.Physics.Move_005
             float bodyRadius = _body.ComputeDistanceToEdge(direction);
 
             step = distance < bodyRadius ? distance : bodyRadius;
-            if (_body.CastAABB(direction, step + ContactOffset, out obstruction))
+            if (_body.CastAABB(direction, step + ContactOffset, out var hits))
             {
+                obstruction = hits[0];
                 float distancePastOffset = obstruction.distance - ContactOffset;
                 step = distancePastOffset < Epsilon? 0f : distancePastOffset;
+            }
+            else
+            {
+                obstruction = default;
             }
 
             _body.Position += step * direction;

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/_Move_005__SurfaceSlidingGravity.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/_Move_005__SurfaceSlidingGravity.unity
@@ -203,11 +203,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.5
+      value: 22.5
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1
+      value: 2.5
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/_Move_005__SurfaceSlidingGravity.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_005__SurfaceSlidingGravity/_Move_005__SurfaceSlidingGravity.unity
@@ -203,11 +203,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 22.5
+      value: 22.4
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.5
+      value: 1.65
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z


### PR DESCRIPTION
Various micro-improvements to polish the solver.

Specifically, now we actively prevent contacts from being formed by always biasing outward from them.


UPDATE: Below will addressed separately next in another PR, since requires further rework.

Additionally, we address the following problem:
*u-shaped surface - infinite movement if moving down*
![u-shaped-surface-infinite-movement-if-moving-down](https://github.com/jeffreypersons/Penguin-Quest/assets/8084757/50ad1d81-3783-490b-9537-fa836d09cb87).
The above is an issue since we typically only care about the closest collision contact.
Yet in the above corner case, that has the following repurcussions:
* if you move down, then you get slight overlap on the right side
* if you keep holding down button, then that x-component of the overlap-resolution will cause you to overlap on the left side
this repeats, causing a shake
* desired outcome, is no movement

