### PR TITLE
[Physics] Avoid snapping body to otherside of edge collider when resolving overlap

### DIFF
--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -59,7 +59,7 @@ namespace PQ._Experimental.Physics.Move_006
             Debug.Log("enter");
             if (!_kinematicBody.IsFilteringLayerMask(collision.collider.gameObject))
             {
-                _kinematicSolver.RemoveOverlap(collision);
+                _kinematicSolver.ResolveOverlap(collision);
             }
         }
 
@@ -68,7 +68,7 @@ namespace PQ._Experimental.Physics.Move_006
             Debug.Log("stay");
             if (!_kinematicBody.IsFilteringLayerMask(collision.collider.gameObject))
             {
-                _kinematicSolver.RemoveOverlap(collision);
+                _kinematicSolver.ResolveOverlap(collision);
             }
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -50,25 +50,22 @@ namespace PQ._Experimental.Physics.Move_006
                 _kinematicSolver.Flip(horizontal: _inputAxis.x < 0, vertical: false);
             }
 
-            Vector2 deltaPosition = Time.fixedDeltaTime * _moveSpeed * _inputAxis;
-            _kinematicSolver.Move(deltaPosition);
+            _kinematicSolver.Move(distance: Time.fixedDeltaTime * _moveSpeed, direction: _inputAxis);
         }
 
         void OnCollisionEnter2D(Collision2D collision)
         {
-            Debug.Log("enter");
             if (!_kinematicBody.IsFilteringLayerMask(collision.collider.gameObject))
             {
-                _kinematicSolver.ResolveOverlap(collision);
+                _kinematicSolver.ResolveSeparation(collision.collider);
             }
         }
 
         void OnCollisionStay2D(Collision2D collision)
         {
-            Debug.Log("stay");
             if (!_kinematicBody.IsFilteringLayerMask(collision.collider.gameObject))
             {
-                _kinematicSolver.ResolveOverlap(collision);
+                _kinematicSolver.ResolveSeparation(collision.collider);
             }
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -46,10 +46,12 @@ namespace PQ._Experimental.Physics.Move_006
         In practice, this is not an issue except when spawning, as any movement in the solver caps changes in position be no
         greater than the body extents.
         */
-        public void RemoveOverlap(Collision2D collision)
+        public void ResolveOverlap(Collision2D collision)
         {
-
+            bool before = _body.IsCenterBoundedByAnEdgeCollider(out var edgeBefore);
             SnapToClosestDistance(collision.collider);
+            bool after = _body.IsCenterBoundedByAnEdgeCollider(out var edgeAfter);
+            Debug.Log($"before={before} after={after}");
         }
 
         /*

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -8,8 +8,10 @@ namespace PQ._Experimental.Physics.Move_006
     Collide and slide solver for movement.
 
     Notes
+    - Prevents tunneling by clamping an movement sub-step to body extents (allowing backtracking if overlap)
+    - Flipping is done only by local rotation along x and y axes - no changes in scale
     - When moving along surfaces, we maintain a slight offset from the normal, such that contacts are
-      intentionally avoided. This way, we avoid getting caught on edges and corners as easily      
+      intentionally avoided. This way, we avoid getting caught on edges and corners 
     */
     internal sealed class KinematicLinearSolver2D
     {
@@ -37,40 +39,29 @@ namespace PQ._Experimental.Physics.Move_006
             _body = kinematicBody2D;
         }
 
-        /*
-        Note that with edge colliders, the collider will end up on either side, as there is no 'internal area'.
-
-        This means that if our body starts in more overlapped position than separated from an edge collider, it will
-        resolve to the 'inside' of the edge.
-        
-        In practice, this is not an issue except when spawning, as any movement in the solver caps changes in position be no
-        greater than the body extents.
-        */
-        public void ResolveOverlap(Collision2D collision)
-        {
-            bool before = _body.IsCenterBoundedByAnEdgeCollider(out var edgeBefore);
-            SnapToClosestDistance(collision.collider);
-            bool after = _body.IsCenterBoundedByAnEdgeCollider(out var edgeAfter);
-            Debug.Log($"before={before} after={after}");
-        }
 
         /*
-        Note that with edge colliders, the collider will end up on either side, as there is no 'internal area'.
+        Resolve any separation between given body and collider.
 
-        This means that if our body starts in more overlapped position than separated from an edge collider, it will
-        resolve to the 'inside' of the edge.
-        
-        In practice, this is not an issue except when spawning, as any movement in the solver caps changes in position be no
-        greater than the body extents.
+        Reposition body to touch collider with no gap or overlap (or until max iterations reached)
+        - Safeguards against passing through collider when resolving separation
+        - Since separation is solved iteratively in linear steps, complex geometry (ie many concave faces) require more iterations
         */
-        public void SnapToClosestDistance(Collider2D collider)
+        public void ResolveSeparation(Collider2D collider)
         {
-            // note that we remove separation if ever so slightly above surface as well
             Vector2 startPosition = _body.Position;
             int iteration = MaxOverlapIterations;
             ColliderDistance2D separation = _body.ComputeMinimumSeparation(collider);
 
-            while (iteration-- > 0 && separation.distance < Epsilon)
+            // if collider is entered when resolving resolution, then start further out
+            // specifically this prevents bodies from snapping to the other side of an edge collider
+            if (_body.CastRayAt(collider, startPosition, separation.normal, separation.distance, out var _))
+            {
+                _body.Position += -2f * _body.ComputeDistanceToEdge(separation.normal) * separation.normal;
+            }
+
+            // note that we remove separation if ever so slightly above surface as well
+            while (iteration-- > 0 && separation.distance is < -Epsilon or > Epsilon)
             {
                 Vector2 beforeStep = _body.Position;
                 separation = _body.ComputeMinimumSeparation(collider);
@@ -84,14 +75,19 @@ namespace PQ._Experimental.Physics.Move_006
             Vector2 endPosition = _body.Position;
 
             // bias the resolved position ever so slightly along the normal to prevent contact
-
             _body.Position += Epsilon * (endPosition - startPosition).normalized;
         }
 
+
+        /*
+        Set direction of body via local xy axes. Note does not change scale.
+
+        Defaults to right and up, and left and down respectively, if inverted.
+        */
         public void Flip(bool horizontal, bool vertical)
         {
             Vector3 rotation = new Vector3(
-                x: vertical ? 180f : 0f,
+                x: vertical   ? 180f : 0f,
                 y: horizontal ? 180f : 0f,
                 z: 0f);
 
@@ -101,33 +97,39 @@ namespace PQ._Experimental.Physics.Move_006
             }
         }
 
-        /* Project AABB along delta until (if any) obstruction. Max distance caps at body-radius to prevent tunneling. */
-        public void Move(Vector2 delta)
+
+        /*
+        Move body by given change in position, taking surface contacts into account.
+
+        Body is moved along surfaces until either distance, obstruction in opposing direction (ie wall), or max iterations are reached
+        - Tunneling is avoided by clamping distance moved per iteration to body extents (allowing backtracking if overlap)
+        - Sticking to corners is avoided by maintaining a slight offset from all surface contact normals
+        - Steps are done linearly, allowing for an arbitrary surface to be moved along
+        */
+        public void Move(float distance, Vector2 direction)
         {
             // note that we compare extremely close to zero rather than our larger epsilon,
             // as delta can be very small depending on the physics step duration used to compute it
-            if (delta == Vector2.zero)
+            if (distance * direction == Vector2.zero)
             {
                 return;
             }
 
             Vector2 startPosition = _body.Position;
             int iteration = MaxMoveIterations;
-            float distanceRemaining = delta.magnitude;
-            Vector2 direction = delta.normalized;
             while (iteration-- > 0 &&
-                   distanceRemaining > Epsilon &&
+                   distance > Epsilon &&
                    direction.sqrMagnitude > Epsilon &&
                    !(direction == Vector2.down && CheckForConcaveFaceBelow()))
             {
                 Vector2 beforeStep = _body.Position;
-                Debug.DrawLine(beforeStep, beforeStep + (distanceRemaining * direction), Color.gray, 1f);
+                Debug.DrawLine(beforeStep, beforeStep + (distance * direction), Color.gray, 1f);
                 
-                Debug.Log($"Move({delta}).substep#{MaxMoveIterations-iteration} : " +
-                          $"remaining={distanceRemaining}, direction={direction}");
+                Debug.Log($"Move({distance*direction}).substep#{MaxMoveIterations-iteration} : " +
+                          $"remaining={distance}, direction={direction}");
                 MoveUnobstructed(
                     direction,
-                    distanceRemaining,
+                    distance,
                     out float step,
                     out RaycastHit2D obstruction);
 
@@ -135,7 +137,7 @@ namespace PQ._Experimental.Physics.Move_006
                 Debug.DrawLine(beforeStep, afterStep, Color.green, 1f);
 
                 direction -= obstruction.normal * Vector2.Dot(direction, obstruction.normal);
-                distanceRemaining -= step;
+                distance -= step;
             }
             Vector2 endPosition = _body.Position;
             _body.MovePositionWithoutBreakingInterpolation(startPosition, endPosition);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -203,11 +203,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 22.49
+      value: 20.87
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.65
+      value: 2.369
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -203,11 +203,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 20.87
+      value: 21.352
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.369
+      value: 2.818
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z


### PR DESCRIPTION
Adds a check and makes the solver more robust such that it checks for moving through a collider during the initial separation query.