### PR TITLE
[Physics] Test Scene - Safeguard against separation failing to resolve

### DIFF
--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -18,9 +18,6 @@ namespace PQ._Experimental.Physics.Move_006
 
         void Awake()
         {
-            QualitySettings.vSyncCount = 0;
-            Application.targetFrameRate = 60;
-
             _kinematicBody   = new KinematicBody2D(transform);
             _kinematicSolver = new KinematicLinearSolver2D(_kinematicBody);
             _positionHistory = new CircularBuffer<Vector2>(capacity: 50);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -18,6 +18,7 @@ namespace PQ._Experimental.Physics.Move_006
 
         void Awake()
         {
+            QualitySettings.vSyncCount = 0;
             Application.targetFrameRate = 60;
 
             _kinematicBody   = new KinematicBody2D(transform);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -57,7 +57,7 @@ namespace PQ._Experimental.Physics.Move_006
             // specifically this prevents bodies from snapping to the other side of an edge collider
             if (_body.CastRayAt(collider, startPosition, separation.normal, separation.distance, out var _))
             {
-                _body.Position += -2f * _body.ComputeDistanceToEdge(separation.normal) * separation.normal;
+                _body.Position += -_body.ComputeDistanceToEdge(separation.normal) * separation.normal;
             }
 
             // note that we remove separation if ever so slightly above surface as well
@@ -113,15 +113,6 @@ namespace PQ._Experimental.Physics.Move_006
             {
                 return;
             }
-
-            _body.Position -= new Vector2(0, 0.2f);
-            ContactFlags2D flags = _body.CheckSides();
-            if (flags.HasFlag(ContactFlags2D.BottomLeftCorner))
-            {
-                _body.Position += new Vector2(0, 0.2f);
-                return;
-            }
-            _body.Position += new Vector2(0, 0.2f);
 
             Vector2 startPosition = _body.Position;
             int iteration = MaxMoveIterations;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -56,7 +56,7 @@ namespace PQ._Experimental.Physics.Move_006
             // specifically this prevents bodies from snapping to the other side of an edge collider
             if (_body.CastRayAt(collider, _body.Position, separation.normal, separation.distance, out var _))
             {
-                Debug.Log($"RemoveOverlap({collider.name}) : initial resolution caused collider to pass through an edge - pushing back to compensate");
+                Debug.Log($"RemoveOverlap({collider.name}) : Initial resolution caused collider to pass through an edge - pushing back to compensate");
                 _body.Position += -2f * _body.ComputeDistanceToEdge(separation.normal) * separation.normal;
             }
 
@@ -64,10 +64,20 @@ namespace PQ._Experimental.Physics.Move_006
             Vector2 startPosition = _body.Position;
             while (iteration-- > 0 && separation.distance is < -Epsilon or > Epsilon)
             {
+                ColliderDistance2D previousSeparation = separation;
                 Vector2 beforeStep = _body.Position;
                 separation = _body.ComputeMinimumSeparation(collider);
+
                 Debug.Log($"RemoveOverlap({collider.name}).substep#{MaxOverlapIterations - iteration} : " +
                           $"remaining={separation.distance}, direction={separation.normal}");
+
+                if (separation.distance >= previousSeparation.distance)
+                {
+                    // typically this only occurs on sharp protruding angles where the body can catapult away from surface normal
+                    // so any time we are trying to converge the separation to zero, stop as a safeguard
+                    Debug.Log($"RemoveOverlap({collider.name}) : Separation amount increased - halting resolution");
+                    break;
+                }
                 _body.Position += separation.distance * separation.normal;
 
                 Vector2 afterStep = _body.Position;
@@ -76,6 +86,7 @@ namespace PQ._Experimental.Physics.Move_006
             Vector2 endPosition = _body.Position;
 
             // bias the resolved position ever so slightly along the normal to prevent contact
+            // note this also prevents infinite flip flopping if body is placed exactly at the center of an overlapping collider
             _body.Position += Epsilon * (endPosition - startPosition).normalized;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -56,7 +56,8 @@ namespace PQ._Experimental.Physics.Move_006
             // specifically this prevents bodies from snapping to the other side of an edge collider
             if (_body.CastRayAt(collider, _body.Position, separation.normal, separation.distance, out var _))
             {
-                _body.Position += -_body.ComputeDistanceToEdge(separation.normal) * separation.normal;
+                Debug.Log($"RemoveOverlap({collider.name}) : initial resolution caused collider to pass through an edge - pushing back to compensate");
+                _body.Position += -2f * _body.ComputeDistanceToEdge(separation.normal) * separation.normal;
             }
 
             // note that we remove separation if ever so slightly above surface as well

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -49,18 +49,18 @@ namespace PQ._Experimental.Physics.Move_006
         */
         public void ResolveSeparation(Collider2D collider)
         {
-            Vector2 startPosition = _body.Position;
             int iteration = MaxOverlapIterations;
             ColliderDistance2D separation = _body.ComputeMinimumSeparation(collider);
 
             // if collider is entered when resolving resolution, then start further out
             // specifically this prevents bodies from snapping to the other side of an edge collider
-            if (_body.CastRayAt(collider, startPosition, separation.normal, separation.distance, out var _))
+            if (_body.CastRayAt(collider, _body.Position, separation.normal, separation.distance, out var _))
             {
                 _body.Position += -_body.ComputeDistanceToEdge(separation.normal) * separation.normal;
             }
 
             // note that we remove separation if ever so slightly above surface as well
+            Vector2 startPosition = _body.Position;
             while (iteration-- > 0 && separation.distance is < -Epsilon or > Epsilon)
             {
                 Vector2 beforeStep = _body.Position;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -97,7 +97,6 @@ namespace PQ._Experimental.Physics.Move_006
             }
         }
 
-
         /*
         Move body by given change in position, taking surface contacts into account.
 
@@ -115,12 +114,21 @@ namespace PQ._Experimental.Physics.Move_006
                 return;
             }
 
+            _body.Position -= new Vector2(0, 0.2f);
+            ContactFlags2D flags = _body.CheckSides();
+            if (flags.HasFlag(ContactFlags2D.BottomLeftCorner))
+            {
+                _body.Position += new Vector2(0, 0.2f);
+                return;
+            }
+            _body.Position += new Vector2(0, 0.2f);
+
             Vector2 startPosition = _body.Position;
             int iteration = MaxMoveIterations;
             while (iteration-- > 0 &&
                    distance > Epsilon &&
-                   direction.sqrMagnitude > Epsilon &&
-                   !(direction == Vector2.down && CheckForConcaveFaceBelow()))
+                   direction.sqrMagnitude > Epsilon
+                   /*&&!(direction == Vector2.down && CheckForConcaveFaceBelow())*/)
             {
                 Vector2 beforeStep = _body.Position;
                 Debug.DrawLine(beforeStep, beforeStep + (distance * direction), Color.gray, 1f);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -203,11 +203,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 21.352
+      value: 22.35
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.818
+      value: 1.65
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z


### PR DESCRIPTION
There is a corner case (literally) where the body can be moved too far away from normal, causing more separation.

If that happens, we stop the loop.

I've yet to see this happen for more typical geometries, but for moving towards something like below, I was able to reproduce this for the below, where we get over-correction on moving left:
![geometry-example](https://github.com/jeffreypersons/Penguin-Quest/assets/8084757/38d7f4f3-f434-43b7-a5f5-a448d2299699)
