### PR TITLE
[Physics] Test Scene - Fix concave check and apply once before iterating

### DIFF
--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -324,7 +324,7 @@ namespace PQ._Experimental.Physics.Move_006
                 Debug.DrawLine(origin, origin + distance * normal, Color.red, 1f);
                 if (_hitBufferSecondary[rayIndex])
                 {
-                    Debug.DrawLine(origin, _hitBufferSecondary[0].point, Color.green, 1f);
+                    Debug.DrawLine(origin, origin + _hitBufferSecondary[rayIndex].distance * normal, Color.green, 1f);
                 }
                 #endif
             }

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -352,20 +352,21 @@ namespace PQ._Experimental.Physics.Move_006
         /*
         Map given direction to a side, returning it's normal and start end points.
         Relative to right world-axis, angles map as (315,45]=>right (45,135]=>top (135,180]=>left (180,315]=>bottom
+        Note that start is from bottom and left respectively.
         */
         private (Vector2 normal, Vector2 start, Vector2 end) FindIntersectingSide(Vector2 direction)
         {
             // map angle to side's normal and corner coordinates, checking from lower right corner of the box
-            float degrees = Vector2.SignedAngle(new Vector2(-1, -1), direction);
-            if (degrees < 0)
+            float degrees = Vector2.SignedAngle(new Vector2(1, -1), direction);
+            if (degrees <= 0)
             {
-                degrees = 360f - degrees;
+                degrees = 360f + degrees;
             }
             (Vector2 normal, Vector2 cornerStart, Vector2 cornerEnd) = degrees switch
             {
-                <= 90f  => (Vector2.right, new Vector2(-1, -1), new Vector2(-1,  1)),
-                <= 180f => (Vector2.up,    new Vector2( 1, -1), new Vector2( 1,  1)),
-                <= 270f => (Vector2.left,  new Vector2(-1,  1), new Vector2( 1,  1)),
+                <= 90f  => (Vector2.right, new Vector2( 1, -1), new Vector2( 1,  1)),
+                <= 180f => (Vector2.up,    new Vector2(-1,  1), new Vector2( 1,  1)),
+                <= 270f => (Vector2.left,  new Vector2(-1, -1), new Vector2(-1,  1)),
                 _       => (Vector2.down,  new Vector2(-1, -1), new Vector2( 1, -1)),
             };
             

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -306,11 +306,11 @@ namespace PQ._Experimental.Physics.Move_006
 
             int totalHits = 0;
             (Vector2 normal, Vector2 start, Vector2 end) = FindIntersectingSide(direction);
-            Vector2 delta = (end - start) / rayCount;
+            Vector2 delta = (end - start) / (rayCount-1);
             for (int rayIndex = 0; rayIndex < rayCount; rayIndex++)
             {
                 Vector2 origin = start + (rayIndex * delta);
-                if (Physics2D.Raycast(origin, direction, _contactFilter, _hitBuffer, distance) > 0)
+                if (Physics2D.Raycast(origin, normal, _contactFilter, _hitBuffer, distance) > 0)
                 {
                     totalHits++;
                     _hitBufferSecondary[rayIndex] = _hitBuffer[0];
@@ -321,7 +321,7 @@ namespace PQ._Experimental.Physics.Move_006
                 }
 
                 #if UNITY_EDITOR
-                Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
+                Debug.DrawLine(origin, origin + distance * normal, Color.red, 1f);
                 if (_hitBufferSecondary[rayIndex])
                 {
                     Debug.DrawLine(origin, _hitBufferSecondary[0].point, Color.green, 1f);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -356,16 +356,16 @@ namespace PQ._Experimental.Physics.Move_006
         private (Vector2 normal, Vector2 start, Vector2 end) FindIntersectingSide(Vector2 direction)
         {
             // map angle to side's normal and corner coordinates, checking from lower right corner of the box
-            float degrees = Vector2.Angle(new Vector2(-1, -1), direction);
-            if (direction.y < 0)
+            float degrees = Vector2.SignedAngle(new Vector2(-1, -1), direction);
+            if (degrees < 0)
             {
                 degrees = 360f - degrees;
             }
             (Vector2 normal, Vector2 cornerStart, Vector2 cornerEnd) = degrees switch
             {
-                <= 90f  => (Vector2.left,  new Vector2(-1, -1), new Vector2(-1,  1)),
-                <= 180f => (Vector2.right, new Vector2( 1, -1), new Vector2( 1,  1)),
-                <= 270f => (Vector2.up,    new Vector2(-1,  1), new Vector2( 1,  1)),
+                <= 90f  => (Vector2.right, new Vector2(-1, -1), new Vector2(-1,  1)),
+                <= 180f => (Vector2.up,    new Vector2( 1, -1), new Vector2( 1,  1)),
+                <= 270f => (Vector2.left,  new Vector2(-1,  1), new Vector2( 1,  1)),
                 _       => (Vector2.down,  new Vector2(-1, -1), new Vector2( 1, -1)),
             };
             

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -173,6 +173,7 @@ namespace PQ._Experimental.Physics.Move_006
             // so we if we detect one, treat it as a wall
             if (CheckForObstructingConcaveSurface(direction, maxStep, out RaycastHit2D normalizedHit))
             {
+                Debug.Log("DADA");
                 obstruction = normalizedHit;
             }
             else

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -126,6 +126,19 @@ namespace PQ._Experimental.Physics.Move_006
                 return;
             }
 
+            // closest hit is sufficient for all cases except concave surfaces that will cause back and forth
+            // movement due to 'flip-flopping' surface normals, so we if we detect one, treat it as a wall
+            if (Vector2.Dot(direction, Vector2.right) is -1 or 0 or 1 &&
+                CheckForObstructingConcaveSurface(direction, _body.ComputeDistanceToEdge(direction), out float delta, out RaycastHit2D normalizedHit) &&
+                delta < Epsilon)
+            {
+                // todo: determine if epsilon is sufficient by trying different concave shapes
+                // todo: fix the normalized point drawn here
+                Debug.Log("Move - trying to move into center of concave section - aborting");
+                Debug.DrawLine(_body.Position, normalizedHit.point, Color.blue, 1f);
+                return;
+            }
+
             Vector2 startPosition = _body.Position;
             int iteration = MaxMoveIterations;
             while (iteration-- > 0 &&
@@ -160,35 +173,26 @@ namespace PQ._Experimental.Physics.Move_006
             float bodyRadius = _body.ComputeDistanceToEdge(direction);
 
             float maxStep = distance < bodyRadius ? distance : bodyRadius;
-            if (!_body.CastAABB(direction, maxStep + ContactOffset, out var closestHit))
+            if (_body.CastAABB(direction, maxStep + ContactOffset, out var closestHit))
             {
-                obstruction = default;
-                step = maxStep;
-                _body.Position += step * direction;
-                return;
-            }
-
-            // closest hit is sufficient for all cases except concave surfaces that will cause back and forth
-            // movement due to 'flip-flopping' surface normals
-            // so we if we detect one, treat it as a wall
-            if (CheckForObstructingConcaveSurface(direction, maxStep, out RaycastHit2D normalizedHit))
-            {
-                Debug.Log("DADA");
-                obstruction = normalizedHit;
+                obstruction = closestHit;
+                step = closestHit.distance;
             }
             else
             {
-                obstruction = closestHit;
+                obstruction = default;
+                step = maxStep;
             }
 
-            float distancePastOffset = closestHit.distance - ContactOffset;
+            float distancePastOffset = step - ContactOffset;
             step = distancePastOffset < Epsilon ? 0f : distancePastOffset;
             _body.Position += step * direction;
         }
 
 
-        private bool CheckForObstructingConcaveSurface(Vector2 direction, float distance, out RaycastHit2D normalizedHit)
+        private bool CheckForObstructingConcaveSurface(Vector2 direction, float distance, out float delta, out RaycastHit2D normalizedHit)
         {
+            delta = 0f;
             normalizedHit = default;
 
             _body.CastRaysFromSide(direction, distance, rayCount: 3, out var hitCount, out var results);
@@ -210,6 +214,7 @@ namespace PQ._Experimental.Physics.Move_006
             }
 
             // construct a hit equivalent to moving towards a flat wall spanning between the left and right hits
+            delta = Mathf.Abs(leftHit.distance - rightHit.distance);
             normalizedHit          = leftHit.distance < rightHit.distance ? leftHit : rightHit;
             normalizedHit.centroid = middleHit.centroid;
             normalizedHit.point    = middleHit.centroid + normalizedHit.distance * direction;


### PR DESCRIPTION
Fix concave check and apply once before iterating.
This is the last known major bug of the solver.

I solve the issue of flip-flopping normals by treating concave surfaces in front of a side that is being moved directly parallel too, as the 'inner-most' part of the concave section, normalize the hit, and treat it as if it was a wall.