### PR TITLE
[Physics] Test Scene - Handle moving diagonally into obtuse corners

### DIFF
--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -67,6 +67,17 @@ namespace PQ._Experimental.Physics.Move_006
             }
         }
 
+        void OnCollisionExit2D(Collision2D collision)
+        {
+            /*
+            if (!_kinematicBody.IsFilteringLayerMask(collision.collider.gameObject))
+            {
+                var sep = _kinematicBody.ComputeMinimumSeparation(collision.collider);
+                _kinematicBody.Position += -KinematicLinearSolver2D.Epsilon * sep.normal;
+            }
+            */
+        }
+
         void OnDrawGizmos()
         {
             if (!Application.IsPlaying(this) || _positionHistory.Size < 2)

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -342,6 +342,7 @@ namespace PQ._Experimental.Physics.Move_006
         public float ComputeDistanceToEdge(Vector2 direction)
         {
             Bounds bounds = _boxCollider.bounds;
+            bounds.Expand(_boxCollider.edgeRadius);
             bounds.IntersectRay(new Ray(bounds.center, direction), out float distanceFromCenterToEdge);
 
             // discard sign since distance is negative if starts within bounds (contrary to other ray methods)

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -495,13 +495,13 @@ namespace PQ._Experimental.Physics.Move_006
             {
                 degrees = 360f + degrees;
             }
-            Vector2 normal = degrees switch
+            Vector2 normal = (degrees switch
             {
                 <= 90f  => (new Vector2( 1, -1)),
                 <= 180f => (new Vector2( 1,  1)),
                 <= 270f => (new Vector2(-1,  1)),
                 _       => (new Vector2(-1, -1)),
-            };
+            }).normalized;
             
             Vector2 center = _boxCollider.bounds.center;
             Vector2 extents = (Vector2)_boxCollider.bounds.extents + new Vector2(_boxCollider.edgeRadius, _boxCollider.edgeRadius);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -273,6 +273,14 @@ namespace PQ._Experimental.Physics.Move_006
                 hit = default;
             }
             EnableCollisionsWithAABB();
+
+            #if UNITY_EDITOR
+            Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
+            if (hit)
+            {
+                Debug.DrawLine(origin, hit.point, Color.green, 1f);
+            }
+            #endif
             return hit;
         }
 
@@ -290,6 +298,14 @@ namespace PQ._Experimental.Physics.Move_006
                 hit = _hitBuffer[0];
             }
             EnableCollisionsWithAABB();
+            
+            #if UNITY_EDITOR
+            Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
+            if (hit)
+            {
+                Debug.DrawLine(origin, hit.point, Color.green, 1f);
+            }
+            #endif
             return hit;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -341,6 +341,9 @@ namespace PQ._Experimental.Physics.Move_006
         */
         public float ComputeDistanceToEdge(Vector2 direction)
         {
+            // todo: consider calculating distance mathematically in a way that accounts for rounded corners due to edge radius
+            //       alternatively, this could be done by subtracting radial distance in proportion to where the ray hits the
+            //       crosses over in the corner region. this could be done by checking if it intersects the small bounded corner region
             Bounds bounds = _boxCollider.bounds;
             bounds.Expand(_boxCollider.edgeRadius);
             bounds.IntersectRay(new Ray(bounds.center, direction), out float distanceFromCenterToEdge);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -389,6 +389,7 @@ namespace PQ._Experimental.Physics.Move_006
             Vector2 tangent = Vector2.Perpendicular(normal);
             Vector2 start = position + spreadExtent * tangent;
             Vector2 end = position - spreadExtent * tangent;
+            Debug.DrawLine(start, end, Color.blue, 1f);
 
             Vector2 delta = (end - start) / (rayCount-1);
             for (int rayIndex = 0; rayIndex < rayCount; rayIndex++)
@@ -495,17 +496,17 @@ namespace PQ._Experimental.Physics.Move_006
             {
                 degrees = 360f + degrees;
             }
-            Vector2 normal = (degrees switch
+            Vector2 offset = degrees switch
             {
-                <= 90f  => (new Vector2( 1, -1)),
-                <= 180f => (new Vector2( 1,  1)),
-                <= 270f => (new Vector2(-1,  1)),
-                _       => (new Vector2(-1, -1)),
-            }).normalized;
+                <= 90f  => new Vector2( 1, -1),
+                <= 180f => new Vector2( 1,  1),
+                <= 270f => new Vector2(-1,  1),
+                _       => new Vector2(-1, -1),
+            };
             
             Vector2 center = _boxCollider.bounds.center;
             Vector2 extents = (Vector2)_boxCollider.bounds.extents + new Vector2(_boxCollider.edgeRadius, _boxCollider.edgeRadius);
-            return (normal, center + extents * normal);
+            return (offset.normalized, center + extents * offset);
         }
 
         /*

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -108,6 +108,11 @@ namespace PQ._Experimental.Physics.Move_006
             return _contactFilter.IsFilteringLayerMask(other);
         }
 
+        public bool IsTouching()
+        {
+            return _boxCollider.IsTouching(_contactFilter);
+        }
+
         /*
         Use separating axis theorem to determine distance needed for no overlap.
         
@@ -201,6 +206,21 @@ namespace PQ._Experimental.Physics.Move_006
             }
             _contactFilter.useNormalAngle = false;
             return flags;
+        }
+
+        /*
+        Check for overlapping colliders within our bounding box.
+        */
+        public bool CheckForOverlappingColliders(Vector2 extents, out ReadOnlySpan<Collider2D> colliders)
+        {
+            int layer = _transform.gameObject.layer;
+            _transform.gameObject.layer = Physics2D.IgnoreRaycastLayer;
+
+            int colliderCount = Physics2D.OverlapBox(_boxCollider.bounds.center, 2f * extents, 0f, _contactFilter, _overlapBuffer);
+            colliders = _overlapBuffer.AsSpan(0, colliderCount);
+
+            _transform.gameObject.layer = layer;
+            return !colliders.IsEmpty;
         }
 
         /*

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -188,12 +188,12 @@ namespace PQ._Experimental.Physics.Move_006
                 Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.magenta, 1f);
             }
 
-            Vector2 edgePoint = _body.Position + (_body.ComputeDistanceToEdge(direction)) * direction;
-            if (_body.CastCircle(edgePoint, ContactOffset, direction, ContactOffset + Epsilon, out RaycastHit2D circleHit) &&
-                circleHit.distance < ContactOffset)
+            float bodyRadius = _body.ComputeDistanceToEdge(direction);
+            if (_body.CastCircle(_body.Position, ContactOffset, direction, bodyRadius + 2f * ContactOffset, out RaycastHit2D circleHit) &&
+                (circleHit.distance - bodyRadius) < ContactOffset)
             {
                 obstruction = circleHit;
-                float contactOffsetCorrection = ContactOffset - circleHit.distance;
+                float contactOffsetCorrection = circleHit.distance - bodyRadius;
                 step += contactOffsetCorrection;
                 _body.Position -= contactOffsetCorrection * direction;
             }

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -147,6 +147,7 @@ namespace PQ._Experimental.Physics.Move_006
             {
                 Debug.Log("Move - trying to move into center of concave section - aborting");
                 Debug.DrawLine(normalizedCornerHit.centroid, normalizedCornerHit.point, Color.yellow, 1f);
+                return;
             }
 
             Vector2 startPosition = _body.Position;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -134,14 +134,18 @@ namespace PQ._Experimental.Physics.Move_006
             // closest hit is sufficient for all cases except concave surfaces that will cause back and forth
             // movement due to 'flip-flopping' surface normals, so we if we detect one, treat it as a wall
             if (IsPerpendicularDirection(direction) &&
-                CheckForObstructingConcaveSurface(direction, maxStep, out float delta, out RaycastHit2D normalizedHit) &&
-                delta < ContactOffset)
+                CheckForObstructingConcaveSurface(direction, maxStep, out float concaveDelta, out RaycastHit2D normalizedConcaveHit) &&
+                concaveDelta < ContactOffset)
             {
-                // todo: determine if epsilon is sufficient by trying different concave shapes
-                // todo: fix the normalized point drawn here
                 Debug.Log("Move - trying to move into center of concave section - aborting");
-                Debug.DrawLine(normalizedHit.centroid, normalizedHit.point, Color.blue, 1f);
+                Debug.DrawLine(normalizedConcaveHit.centroid, normalizedConcaveHit.point, Color.blue, 1f);
                 return;
+            }
+            if (IsDiagonalDirection(direction) && CheckForProblematicCorner(direction, distance, out float cornerDelta, out RaycastHit2D normalizedCornerHit) &&
+                cornerDelta < ContactOffset)
+            {
+                Debug.Log("Move - trying to move into center of concave section - aborting");
+                Debug.DrawLine(normalizedCornerHit.centroid, normalizedCornerHit.point, Color.yellow, 1f);
             }
 
             Vector2 startPosition = _body.Position;
@@ -189,7 +193,7 @@ namespace PQ._Experimental.Physics.Move_006
             }
 
             float bodyRadius = _body.ComputeDistanceToEdge(direction);
-            if (_body.CastCircle(_body.Position, ContactOffset, direction, bodyRadius + 2f * ContactOffset, out RaycastHit2D circleHit) &&
+            if (_body.CastRay(_body.Position, direction, bodyRadius + ContactOffset, out RaycastHit2D circleHit) &&
                 (circleHit.distance - bodyRadius) < ContactOffset)
             {
                 obstruction = circleHit;
@@ -198,6 +202,40 @@ namespace PQ._Experimental.Physics.Move_006
                 _body.Position -= contactOffsetCorrection * direction;
             }
             _body.Position += step * direction;
+        }
+
+        private bool CheckForProblematicCorner(Vector2 direction, float distance, out float delta, out RaycastHit2D normalizedHit)
+        {
+            delta = 0f;
+            normalizedHit = default;
+
+            _body.CastRaysFromCorner(ContactOffset, direction, distance, rayCount: 3, out var hitCount, out var results);
+            Debug.Log($"concaveCheck - left={results[0].distance} mid={results[1].distance} right={results[2].distance}");
+
+            // technically it is possible that the collider between left/right/middle along a
+            // body's edge is different, but we're not going to worry about that case
+            RaycastHit2D leftHit = results[0];
+            RaycastHit2D middleHit = results[1];
+            RaycastHit2D rightHit = results[2];
+
+            if (hitCount < 2 || !leftHit || !rightHit)
+            {
+                return false;
+            }
+            if (middleHit && (middleHit.distance <= leftHit.distance || middleHit.distance <= rightHit.distance))
+            {
+                return false;
+            }
+
+            Vector2 midPoint = Vector2.LerpUnclamped(leftHit.centroid, rightHit.centroid, 0.50f);
+
+            // construct a hit equivalent to moving towards a flat wall spanning between the left and right hits
+            delta = Mathf.Abs(leftHit.distance - rightHit.distance);
+            normalizedHit = leftHit.distance < rightHit.distance ? leftHit : rightHit;
+            normalizedHit.centroid = midPoint;
+            normalizedHit.point = midPoint + normalizedHit.distance * direction;
+            normalizedHit.normal = -direction;
+            return true;
         }
 
         private bool CheckForObstructingConcaveSurface(Vector2 direction, float distance, out float delta, out RaycastHit2D normalizedHit)
@@ -240,6 +278,12 @@ namespace PQ._Experimental.Physics.Move_006
 
             float maxStep = distance < bodyRadius ? distance : bodyRadius;
             return maxStep;
+        }
+
+        private bool IsDiagonalDirection(Vector2 direction)
+        {
+            bool areComponentsEqual = Mathf.Approximately(direction.x, direction.y);
+            return areComponentsEqual;
         }
 
         private bool IsPerpendicularDirection(Vector2 direction)

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -144,13 +144,6 @@ namespace PQ._Experimental.Physics.Move_006
                 return;
             }
 
-            Vector2 edgePoint = _body.Position + (_body.ComputeDistanceToEdge(direction)) * direction;
-            if (_body.CastRay(edgePoint, direction, ContactOffset + Epsilon, out RaycastHit2D rayHit) &&
-                rayHit.distance < ContactOffset)
-            {
-                return;
-            }
-
             Vector2 startPosition = _body.Position;
             int iteration = MaxMoveIterations;
             while (iteration-- > 0 &&
@@ -196,10 +189,11 @@ namespace PQ._Experimental.Physics.Move_006
             }
 
             Vector2 edgePoint = _body.Position + (_body.ComputeDistanceToEdge(direction)) * direction;
-            if (_body.CastRay(edgePoint, direction, ContactOffset + Epsilon, out RaycastHit2D rayHit) &&
-                rayHit.distance < ContactOffset)
+            if (_body.CastCircle(edgePoint, ContactOffset, direction, ContactOffset + Epsilon, out RaycastHit2D circleHit) &&
+                circleHit.distance < ContactOffset)
             {
-                float contactOffsetCorrection = ContactOffset - rayHit.distance;
+                obstruction = circleHit;
+                float contactOffsetCorrection = ContactOffset - circleHit.distance;
                 step += contactOffsetCorrection;
                 _body.Position -= contactOffsetCorrection * direction;
             }

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -186,6 +186,8 @@ namespace PQ._Experimental.Physics.Move_006
                 obstruction = default;
             }
 
+            Debug.Log($"move obstruction={(bool)obstruction} close={(closestHit.distance is > 0 and < ContactOffset)}");
+
             _body.Position += step * direction;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -144,6 +144,13 @@ namespace PQ._Experimental.Physics.Move_006
                 return;
             }
 
+            Vector2 edgePoint = _body.Position + (_body.ComputeDistanceToEdge(direction)) * direction;
+            if (_body.CastRay(edgePoint, direction, ContactOffset + Epsilon, out RaycastHit2D rayHit) &&
+                rayHit.distance < ContactOffset)
+            {
+                return;
+            }
+
             Vector2 startPosition = _body.Position;
             int iteration = MaxMoveIterations;
             while (iteration-- > 0 &&
@@ -187,12 +194,16 @@ namespace PQ._Experimental.Physics.Move_006
                 obstruction = default;
                 Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.magenta, 1f);
             }
+
+            Vector2 edgePoint = _body.Position + (_body.ComputeDistanceToEdge(direction)) * direction;
+            if (_body.CastRay(edgePoint, direction, ContactOffset + Epsilon, out RaycastHit2D rayHit) &&
+                rayHit.distance < ContactOffset)
+            {
+                float contactOffsetCorrection = ContactOffset - rayHit.distance;
+                step += contactOffsetCorrection;
+                _body.Position -= contactOffsetCorrection * direction;
+            }
             _body.Position += step * direction;
-            Debug.Log($"move " +
-                $"obs={(bool)obstruction} " +
-                $"close={(closestHit.distance is > 0 and < ContactOffset)} " +
-                $"step={step} " +
-                $"dist={(closestHit.distance is > 0? closestHit.distance.ToString() : "-")}");
         }
 
         private bool CheckForObstructingConcaveSurface(Vector2 direction, float distance, out float delta, out RaycastHit2D normalizedHit)

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -119,6 +119,8 @@ namespace PQ._Experimental.Physics.Move_006
         */
         public void Move(Vector2 direction, float distance)
         {
+            direction.Normalize();
+
             // note that we compare extremely close to zero rather than our larger epsilon,
             // as delta can be very small depending on the physics step duration used to compute it
             if (distance * direction == Vector2.zero)
@@ -182,6 +184,7 @@ namespace PQ._Experimental.Physics.Move_006
                 step = maxStep;
                 obstruction = default;
             }
+
             _body.Position += step * direction;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -135,7 +135,7 @@ namespace PQ._Experimental.Physics.Move_006
             // movement due to 'flip-flopping' surface normals, so we if we detect one, treat it as a wall
             if (IsPerpendicularDirection(direction) &&
                 CheckForObstructingConcaveSurface(direction, maxStep, out float delta, out RaycastHit2D normalizedHit) &&
-                delta < Epsilon)
+                delta < ContactOffset)
             {
                 // todo: determine if epsilon is sufficient by trying different concave shapes
                 // todo: fix the normalized point drawn here

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -284,7 +284,7 @@ namespace PQ._Experimental.Physics.Move_006
 
         private bool IsDiagonalDirection(Vector2 direction)
         {
-            bool areComponentsEqual = Mathf.Approximately(direction.x, direction.y);
+            bool areComponentsEqual = Mathf.Approximately(Mathf.Abs(direction.x), Mathf.Abs(direction.y));
             return areComponentsEqual;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -85,6 +85,7 @@ namespace PQ._Experimental.Physics.Move_006
             }
             Vector2 endPosition = _body.Position;
 
+            // todo: investigate whether we should bias this even if the resolution didn't succeed
             // slightly bias the resolved position along normal to prevent contact
             // also prevents flip-flopping that can occur on subsequent calls when placed at center of an overlapped region
             _body.Position += ContactOffset * (endPosition - startPosition).normalized;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -175,20 +175,24 @@ namespace PQ._Experimental.Physics.Move_006
 
         private void MoveUnobstructed(Vector2 direction, float maxStep, out float step, out RaycastHit2D obstruction)
         {
-            if (_body.CastAABB(direction, maxStep + ContactOffset, out var closestHit))
+            if (_body.CastAABB(direction, maxStep, out var closestHit))
             {
                 step = Mathf.Max(closestHit.distance - ContactOffset, 0f);
                 obstruction = closestHit;
+                Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.cyan, 1f);
             }
             else
             {
-                step = maxStep;
+                step = Mathf.Max(maxStep - ContactOffset, 0f);
                 obstruction = default;
+                Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.magenta, 1f);
             }
-
-            Debug.Log($"move obstruction={(bool)obstruction} close={(closestHit.distance is > 0 and < ContactOffset)}");
-
             _body.Position += step * direction;
+            Debug.Log($"move " +
+                $"obs={(bool)obstruction} " +
+                $"close={(closestHit.distance is > 0 and < ContactOffset)} " +
+                $"step={step} " +
+                $"dist={(closestHit.distance is > 0? closestHit.distance.ToString() : "-")}");
         }
 
         private bool CheckForObstructingConcaveSurface(Vector2 direction, float distance, out float delta, out RaycastHit2D normalizedHit)

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -141,7 +141,8 @@ namespace PQ._Experimental.Physics.Move_006
                 Debug.DrawLine(normalizedConcaveHit.centroid, normalizedConcaveHit.point, Color.blue, 1f);
                 return;
             }
-            if (IsDiagonalDirection(direction) && CheckForProblematicCorner(direction, distance, out float cornerDelta, out RaycastHit2D normalizedCornerHit) &&
+            if (IsDiagonalDirection(direction) &&
+                CheckForProblematicCorner(direction, distance, out float cornerDelta, out RaycastHit2D normalizedCornerHit) &&
                 cornerDelta < ContactOffset)
             {
                 Debug.Log("Move - trying to move into center of concave section - aborting");
@@ -209,8 +210,8 @@ namespace PQ._Experimental.Physics.Move_006
             delta = 0f;
             normalizedHit = default;
 
-            _body.CastRaysFromCorner(ContactOffset, direction, distance, rayCount: 3, out var hitCount, out var results);
-            Debug.Log($"concaveCheck - left={results[0].distance} mid={results[1].distance} right={results[2].distance}");
+            _body.CastRaysFromCorner(_body.SkinWidth, direction, distance, rayCount: 3, out var hitCount, out var results);
+            Debug.Log($"cornerCheck - left={results[0].distance} mid={results[1].distance} right={results[2].distance}");
 
             // technically it is possible that the collider between left/right/middle along a
             // body's edge is different, but we're not going to worry about that case
@@ -231,10 +232,10 @@ namespace PQ._Experimental.Physics.Move_006
 
             // construct a hit equivalent to moving towards a flat wall spanning between the left and right hits
             delta = Mathf.Abs(leftHit.distance - rightHit.distance);
-            normalizedHit = leftHit.distance < rightHit.distance ? leftHit : rightHit;
+            normalizedHit          = leftHit.distance < rightHit.distance ? leftHit : rightHit;
             normalizedHit.centroid = midPoint;
-            normalizedHit.point = midPoint + normalizedHit.distance * direction;
-            normalizedHit.normal = -direction;
+            normalizedHit.point    = midPoint + normalizedHit.distance * direction;
+            normalizedHit.normal   = -direction;
             return true;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -130,7 +130,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 553913253703583256, guid: 1d1c18a065f687044a2368cd3e517c65, type: 3}
       propertyPath: m_EdgeRadius
-      value: 0.015
+      value: 0.0125
       objectReference: {fileID: 0}
     - target: {fileID: 2830441547269114762, guid: 1d1c18a065f687044a2368cd3e517c65, type: 3}
       propertyPath: m_Name
@@ -207,11 +207,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.025
+      value: 1.05
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.475
+      value: 9.455
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z
@@ -547,6 +547,10 @@ PrefabInstance:
     - target: {fileID: 6981010155519417703, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_LocalAABB.m_Extent.y
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
+      propertyPath: m_EdgeRadius
+      value: 0.0125
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.size
@@ -1220,6 +1224,10 @@ PrefabInstance:
     - target: {fileID: 6981010155519417703, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_LocalAABB.m_Extent.y
       value: 2.0259845
+      objectReference: {fileID: 0}
+    - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
+      propertyPath: m_EdgeRadius
+      value: 0.0125
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.size

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -128,6 +128,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 553913253703583256, guid: 1d1c18a065f687044a2368cd3e517c65, type: 3}
+      propertyPath: m_EdgeRadius
+      value: 0.015
+      objectReference: {fileID: 0}
     - target: {fileID: 2830441547269114762, guid: 1d1c18a065f687044a2368cd3e517c65, type: 3}
       propertyPath: m_Name
       value: Preset_Platform_Enclosed

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -132,6 +132,14 @@ PrefabInstance:
       propertyPath: m_EdgeRadius
       value: 0.0125
       objectReference: {fileID: 0}
+    - target: {fileID: 553913253703583256, guid: 1d1c18a065f687044a2368cd3e517c65, type: 3}
+      propertyPath: m_Points.Array.data[70].x
+      value: 0.79534525
+      objectReference: {fileID: 0}
+    - target: {fileID: 553913253703583256, guid: 1d1c18a065f687044a2368cd3e517c65, type: 3}
+      propertyPath: m_Points.Array.data[70].y
+      value: 10.241718
+      objectReference: {fileID: 0}
     - target: {fileID: 2830441547269114762, guid: 1d1c18a065f687044a2368cd3e517c65, type: 3}
       propertyPath: m_Name
       value: Preset_Platform_Enclosed

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -203,11 +203,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.1
+      value: 1.025
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.45
+      value: 9.475
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -8,7 +8,7 @@ Physics2DSettings:
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 10
   m_PositionIterations: 10
-  m_VelocityThreshold: 1
+  m_BounceThreshold: 1
   m_MaxLinearCorrection: 0.01
   m_MaxAngularCorrection: 5
   m_MaxTranslationSpeed: 100
@@ -39,6 +39,13 @@ Physics2DSettings:
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
   m_SimulationMode: 0
+  m_SimulationLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_MaxSubStepCount: 4
+  m_MinSubStepFPS: 30
+  m_UseSubStepping: 0
+  m_UseSubStepContacts: 0
   m_QueriesHitTriggers: 0
   m_QueriesStartInColliders: 0
   m_CallbacksOnDisable: 0


### PR DESCRIPTION
Handle obtuse corners properly with no jitter.
Basically I take the same approach as I do for concave surfaces when moving perpendicularly, see below image:
![up-against-corner](https://github.com/jeffreypersons/Penguin-Quest/assets/8084757/a7e10ea7-df52-4e83-8ebe-e334913774cf)

Also expanded the kinematic body api a bit.
