### PR TITLE
[Physics] Test Scene - Fix corner catching and remaining jitter

### DIFF
--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -9,7 +9,7 @@ namespace PQ._Experimental.Physics.Move_006
         [Range(0,  10)][SerializeField] private float _timeScale = 1f;
         [Range(0, 100)][SerializeField] private float _moveSpeed = 5f;
         
-        #if UNITY_EDITOR        
+        #if UNITY_EDITOR
         [SerializeField] private bool _drawAllCastsFromBody = false;
         private void OnValidate()
         {

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -64,6 +64,7 @@ namespace PQ._Experimental.Physics.Move_006
 
         void OnCollisionEnter2D(Collision2D collision)
         {
+            Debug.Log("OnCollisionEnter2D");
             if (!_kinematicBody.IsFilteringLayerMask(collision.collider.gameObject))
             {
                 _kinematicSolver.ResolveSeparation(collision.collider);
@@ -72,6 +73,7 @@ namespace PQ._Experimental.Physics.Move_006
 
         void OnCollisionStay2D(Collision2D collision)
         {
+            Debug.Log("OnCollisionStay2D");
             if (!_kinematicBody.IsFilteringLayerMask(collision.collider.gameObject))
             {
                 _kinematicSolver.ResolveSeparation(collision.collider);
@@ -80,6 +82,7 @@ namespace PQ._Experimental.Physics.Move_006
 
         void OnCollisionExit2D(Collision2D collision)
         {
+            Debug.Log("OnCollisionExit2D");
             /*
             if (!_kinematicBody.IsFilteringLayerMask(collision.collider.gameObject))
             {

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -6,16 +6,26 @@ namespace PQ._Experimental.Physics.Move_006
 {
     public class Controller : MonoBehaviour
     {
-        [SerializeField] private bool _drawAllCastsFromBody = false;
         [Range(0,  10)][SerializeField] private float _timeScale = 1f;
         [Range(0, 100)][SerializeField] private float _moveSpeed = 5f;
+        
+        #if UNITY_EDITOR        
+        [SerializeField] private bool _drawAllCastsFromBody = false;
+        private void OnValidate()
+        {
+            if (Application.IsPlaying(this) && _kinematicBody != null)
+            {
+                _kinematicBody.DrawCastsInEditor = _drawAllCastsFromBody;
+            }
+        }
+        #endif
+
 
         private Vector2 _inputAxis;
 
         private KinematicBody2D         _kinematicBody;
         private KinematicLinearSolver2D _kinematicSolver;
         private CircularBuffer<Vector2> _positionHistory;
-
 
         void Awake()
         {
@@ -34,7 +44,6 @@ namespace PQ._Experimental.Physics.Move_006
                 x: (Keyboard.current[Key.A].isPressed ? -1f : 0f) + (Keyboard.current[Key.D].isPressed ? 1f : 0f),
                 y: (Keyboard.current[Key.S].isPressed ? -1f : 0f) + (Keyboard.current[Key.W].isPressed ? 1f : 0f)
             );
-            _kinematicBody.DrawCastsInEditor = _drawAllCastsFromBody;
         }
 
         void FixedUpdate()

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/Controller.cs
@@ -6,6 +6,7 @@ namespace PQ._Experimental.Physics.Move_006
 {
     public class Controller : MonoBehaviour
     {
+        [SerializeField] private bool _drawAllCastsFromBody = false;
         [Range(0,  10)][SerializeField] private float _timeScale = 1f;
         [Range(0, 100)][SerializeField] private float _moveSpeed = 5f;
 
@@ -33,6 +34,7 @@ namespace PQ._Experimental.Physics.Move_006
                 x: (Keyboard.current[Key.A].isPressed ? -1f : 0f) + (Keyboard.current[Key.D].isPressed ? 1f : 0f),
                 y: (Keyboard.current[Key.S].isPressed ? -1f : 0f) + (Keyboard.current[Key.W].isPressed ? 1f : 0f)
             );
+            _kinematicBody.DrawCastsInEditor = _drawAllCastsFromBody;
         }
 
         void FixedUpdate()

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -347,7 +347,7 @@ namespace PQ._Experimental.Physics.Move_006
                     hit = _hitBuffer[i];
                     break;
                 }
-            }            
+            }
             EnableCollisionsWithAABB();
             #if UNITY_EDITOR
             DrawCastInEditorIfEnabled(origin, direction, distance, hit? hit.distance : null);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -406,9 +406,8 @@ namespace PQ._Experimental.Physics.Move_006
             int totalHits = 0;
             (Vector2 normal, Vector2 position) = FindClosestCorner(direction);
             Vector2 tangent = Vector2.Perpendicular(normal);
-            Vector2 start = position + spreadExtent * tangent;
-            Vector2 end = position - spreadExtent * tangent;
-            Debug.DrawLine(start, end, Color.blue, 1f);
+            Vector2 start   = position + spreadExtent * tangent;
+            Vector2 end     = position - spreadExtent * tangent;
 
             Vector2 delta = (end - start) / (rayCount-1);
             for (int rayIndex = 0; rayIndex < rayCount; rayIndex++)

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicBody2D.cs
@@ -123,10 +123,10 @@ namespace PQ._Experimental.Physics.Move_006
             _transform.gameObject.layer = _previousLayerMask;
         }
         
-        private void DrawCastIfEnabled(Vector2 origin, Vector2 direction, float distance, RaycastHit2D hit)
+        private void DrawCastIfEnabled(Vector2 origin, Vector2 direction, float distance, RaycastHit2D hit, bool force=false)
         {
             #if UNITY_EDITOR
-            if (_drawRayCasts)
+            if (_drawRayCasts || force)
             {
                 Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
                 if (hit)
@@ -302,17 +302,7 @@ namespace PQ._Experimental.Physics.Move_006
                 hit = default;
             }
             EnableCollisionsWithAABB();
-
-            #if UNITY_EDITOR
-            if (_drawRayCasts)
-            {
-                Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
-                if (hit)
-                {
-                    Debug.DrawLine(origin, hit.point, Color.green, 1f);
-                }
-            }
-            #endif
+            DrawCastIfEnabled(origin, direction, distance, hit);
             return hit;
         }
 
@@ -331,14 +321,6 @@ namespace PQ._Experimental.Physics.Move_006
             }
             EnableCollisionsWithAABB();
             DrawCastIfEnabled(origin, direction, distance, hit);
-
-            #if UNITY_EDITOR
-            Debug.DrawLine(origin, origin + distance * direction, Color.red, 1f);
-            if (hit)
-            {
-                Debug.DrawLine(origin, hit.point, Color.green, 1f);
-            }
-            #endif
             return hit;
         }
 
@@ -422,7 +404,7 @@ namespace PQ._Experimental.Physics.Move_006
                 {
                     _hitBufferSecondary[rayIndex] = default;
                 }
-                DrawCastIfEnabled(origin, direction, distance, _hitBufferSecondary[rayIndex]);
+                DrawCastIfEnabled(origin, direction, distance, _hitBufferSecondary[rayIndex], force:true);
             }
             results = _hitBufferSecondary.AsSpan(0, rayCount);
             hitCount = totalHits;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -137,7 +137,7 @@ namespace PQ._Experimental.Physics.Move_006
                 CheckForObstructingConcaveSurface(direction, maxStep, out float concaveDelta, out RaycastHit2D normalizedConcaveHit) &&
                 concaveDelta < ContactOffset)
             {
-                Debug.Log("Move - trying to move into center of concave section - aborting");
+                Debug.Log("Move - trying to move into center of concave section while already in contact - aborting");
                 Debug.DrawLine(normalizedConcaveHit.centroid, normalizedConcaveHit.point, Color.blue, 1f);
                 return;
             }
@@ -145,7 +145,7 @@ namespace PQ._Experimental.Physics.Move_006
                 CheckForProblematicCorner(direction, distance, out float cornerDelta, out RaycastHit2D normalizedCornerHit) &&
                 cornerDelta < ContactOffset)
             {
-                Debug.Log("Move - trying to move into center of concave section - aborting");
+                Debug.Log("Move - trying to move diagonally into a corner while already in contact - aborting");
                 Debug.DrawLine(normalizedCornerHit.centroid, normalizedCornerHit.point, Color.yellow, 1f);
                 return;
             }

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -199,6 +199,16 @@ namespace PQ._Experimental.Physics.Move_006
                 Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.magenta, 1f);
             }
 
+            float bodyRadius = _body.ComputeDistanceToEdge(direction);
+            if (_body.CastRay(_body.Position, direction, bodyRadius + ContactOffset, out RaycastHit2D circleHit) &&
+                (circleHit.distance - bodyRadius) < ContactOffset)
+            {
+                obstruction = circleHit;
+                float contactOffsetCorrection = circleHit.distance - bodyRadius;
+                Debug.Log($"contactOffsetCorrection={contactOffsetCorrection}");
+                step += contactOffsetCorrection;
+                _body.Position -= contactOffsetCorrection * direction;
+            }
             _body.Position += step * direction;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -54,9 +54,9 @@ namespace PQ._Experimental.Physics.Move_006
 
             if (_body.CastRayAt(collider, _body.Position, separation.normal, separation.distance, out var _))
             {
-                // any time surface is passed through (tunneling), moving back along normal prevents this
-                // can occur when body is heavily overlapped with an edge collider, causing it to 'snap' to the other side
-                Debug.Log($"RemoveOverlap({collider.name}) : Initial resolution caused collider to pass through an edge - pushing back to compensate");
+                // any surface passed through (tunneling) for the initial separation can be prevented by moving back along normal
+                // May occur when body is heavily overlapped with an edge collider causing it 'snap' to other side
+                Debug.Log($"RemoveOverlap({collider.name}).substep#precheck : Initial resolution caused collider to pass through an edge - pushing back to compensate");
                 _body.IntersectAABB(_body.Position, separation.normal, out float distanceToAABBEdge);
                 _body.Position += -2f * distanceToAABBEdge * separation.normal;
             }
@@ -69,13 +69,11 @@ namespace PQ._Experimental.Physics.Move_006
                 Vector2 beforeStep = _body.Position;
                 separation = _body.ComputeMinimumSeparation(collider);
 
-                Debug.Log($"RemoveOverlap({collider.name}).substep#{MaxOverlapIterations - iteration} : " +
-                          $"remaining={separation.distance}, direction={separation.normal}");
+                Debug.Log($"RemoveOverlap({collider.name}).substep#{MaxOverlapIterations - iteration} : remaining={separation.distance}, direction={separation.normal}");
 
                 if (Mathf.Abs(separation.distance) > Mathf.Abs(previousSeparation.distance))
                 {
-                    // any time separation is not decreasing, then stop as a safeguard
-                    // can occur when body moves into a protruding corner causing over-correction
+                    // Any time separation not decreasing then bail out. May occur when moving into a protruding corner causing over-correction.
                     Debug.Log($"RemoveOverlap({collider.name}) : Separation amount increased from {previousSeparation.distance} to {separation.distance} - halting resolution");
                     break;
                 }
@@ -137,7 +135,7 @@ namespace PQ._Experimental.Physics.Move_006
             if (CheckForObstructingConcaveSurface(direction, maxStep, out float concaveDelta, out RaycastHit2D normalizedCenterHit) &&
                 concaveDelta < ContactOffset)
             {
-                Debug.Log($"Move({distance * direction}).substep#0 : remaining={distance}, direction={direction} - obstructed by concave surface");
+                Debug.Log($"Move({distance * direction}) : Obstructed by moving into a concave surface - halting movement");
                 Debug.DrawLine(normalizedCenterHit.centroid, normalizedCenterHit.point, Color.blue, 1f);
                 MoveToAvoidContact(normalizedCenterHit);
                 return;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -150,6 +150,8 @@ namespace PQ._Experimental.Physics.Move_006
                 return;
             }
 
+            Vector2 previousDirection = direction;
+            float previousDistance = distance;
             Vector2 startPosition = _body.Position;
             int iteration = MaxMoveIterations;
             while (iteration-- > 0 &&
@@ -173,6 +175,9 @@ namespace PQ._Experimental.Physics.Move_006
                 direction -= obstruction.normal * Vector2.Dot(direction, obstruction.normal);
                 distance -= step;
                 maxStep = ComputeMaxStep(direction, distance);
+
+                previousDirection = direction;
+                previousDistance = distance;
             }
             Vector2 endPosition = _body.Position;
             _body.MovePositionWithoutBreakingInterpolation(startPosition, endPosition);
@@ -189,20 +194,11 @@ namespace PQ._Experimental.Physics.Move_006
             }
             else
             {
-                step = Mathf.Max(maxStep - ContactOffset, 0f);
+                step = maxStep;
                 obstruction = default;
                 Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.magenta, 1f);
             }
 
-            float bodyRadius = _body.ComputeDistanceToEdge(direction);
-            if (_body.CastRay(_body.Position, direction, bodyRadius + ContactOffset, out RaycastHit2D circleHit) &&
-                (circleHit.distance - bodyRadius) < ContactOffset)
-            {
-                obstruction = circleHit;
-                float contactOffsetCorrection = circleHit.distance - bodyRadius;
-                step += contactOffsetCorrection;
-                _body.Position -= contactOffsetCorrection * direction;
-            }
             _body.Position += step * direction;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -199,7 +199,6 @@ namespace PQ._Experimental.Physics.Move_006
             RaycastHit2D hitA = results[0];
             RaycastHit2D hitB = results[1];
             RaycastHit2D hitC = results[2];
-            Debug.Log($"ConcaveCheck - corner={isDiagonal} distances[A={(hitA?hitA.distance:'-')},B={(hitB?hitB.distance:'-')},C={(hitC?hitC.distance:'-')}]");
             if (hitCount < 2 || !hitA || !hitC)
             {
                 return false;
@@ -209,6 +208,7 @@ namespace PQ._Experimental.Physics.Move_006
                 return false;
             }
 
+            Debug.Log($"ConcaveCheck - corner={isDiagonal} distances[A={(hitA ? hitA.distance : '-')},B={(hitB ? hitB.distance : '-')},C={(hitC ? hitC.distance : '-')}]");
             // construct a hit equivalent to moving towards a flat wall spanning between the first and last hits
             // note that since the collider info cannot be reassigned, the below assumes A and B are same collider
             distanceDifferential = Mathf.Abs(hitA.distance - hitC.distance);
@@ -219,7 +219,6 @@ namespace PQ._Experimental.Physics.Move_006
 
             Debug.DrawLine(hitA.point, hitC.point, Color.black, 1f);
             Debug.DrawLine(normalizedHit.centroid, normalizedHit.point, Color.blue, 1f);
-            Debug.Log($"centroid={normalizedHit.centroid} point={normalizedHit.point}");
             return true;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -215,10 +215,11 @@ namespace PQ._Experimental.Physics.Move_006
             normalizedHit          = hitA.distance < hitC.distance ? hitA : hitC;
             normalizedHit.point    = Vector2.LerpUnclamped(hitA.point, hitC.point, 0.50f);
             normalizedHit.normal   = -direction;
-            normalizedHit.centroid = Vector2.LerpUnclamped(hitA.centroid, hitC.centroid, 0.50f);
+            normalizedHit.centroid = normalizedHit.point - normalizedHit.distance * normalizedHit.normal;
 
             Debug.DrawLine(hitA.point, hitC.point, Color.black, 1f);
             Debug.DrawLine(normalizedHit.centroid, normalizedHit.point, Color.blue, 1f);
+            Debug.Log($"centroid={normalizedHit.centroid} point={normalizedHit.point}");
             return true;
         }
 

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -133,7 +133,7 @@ namespace PQ._Experimental.Physics.Move_006
             // closest hit is sufficient for all cases except concave surfaces that will cause back and forth
             // movement due to 'flip-flopping' surface normals, so we if we detect one, treat it as a wall
             if (CheckForObstructingConcaveSurface(direction, maxStep, out float concaveSampleDistanceDifferential, out RaycastHit2D normalizedCenterHit) &&
-                concaveSampleDistanceDifferential < ContactOffset)
+                (concaveSampleDistanceDifferential < ContactOffset || normalizedCenterHit.distance < ContactOffset))
             {
                 Debug.Log($"Move({distance * direction}) : Obstructed by moving into a concave surface - halting movement");
                 return;
@@ -171,7 +171,6 @@ namespace PQ._Experimental.Physics.Move_006
                 obstruction = default;
             }
             _body.Position += step * direction;
-            MoveToAvoidContact(obstruction);
         }
 
         private bool CheckForObstructingConcaveSurface(Vector2 direction, float distance, out float distanceDifferential, out RaycastHit2D normalizedHit)
@@ -190,7 +189,7 @@ namespace PQ._Experimental.Physics.Move_006
             else if (IsDiagonalDirection(direction))
             {
                 isDiagonal = true;
-                _body.CastRaysFromCorner(spreadExtent: _body.SkinWidth, direction, distance, rayCount: 3, out hitCount, out results);
+                _body.CastRaysFromCorner(spreadExtent: 0.50f * _body.SkinWidth, direction, distance, rayCount: 3, out hitCount, out results);
             }
             else
             {
@@ -200,7 +199,7 @@ namespace PQ._Experimental.Physics.Move_006
             RaycastHit2D hitA = results[0];
             RaycastHit2D hitB = results[1];
             RaycastHit2D hitC = results[2];
-            Debug.Log($"ConcaveCheck - corner={isDiagonal} distances[A={(hitA?hitA.distance:'-')},B={(hitB?hitB.distance:'-')},C={(hitC?hitC.distance:'-')}");
+            Debug.Log($"ConcaveCheck - corner={isDiagonal} distances[A={(hitA?hitA.distance:'-')},B={(hitB?hitB.distance:'-')},C={(hitC?hitC.distance:'-')}]");
             if (hitCount < 2 || !hitA || !hitC)
             {
                 return false;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -159,18 +159,18 @@ namespace PQ._Experimental.Physics.Move_006
 
         private void MoveUnobstructed(Vector2 direction, float maxStep, out float step, out RaycastHit2D obstruction)
         {
+            Debug.DrawLine(_body.Position, _body.Position + maxStep * direction, Color.red, 1f);
             if (_body.CastAABB(direction, maxStep, out var closestHit))
             {
                 step = Mathf.Max(closestHit.distance - ContactOffset, 0f);
                 obstruction = closestHit;
-                Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.cyan, 1f);
-                DebugExtensions.DrawPlus(closestHit.point, new Vector2(ContactOffset, ContactOffset), 45f, Color.yellow, 1f);
+                Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.green, 1f);
+                DebugExtensions.DrawArrow(closestHit.point, closestHit.point + ContactOffset * closestHit.normal, Color.grey, 1f);
             }
             else
             {
                 step = maxStep;
                 obstruction = default;
-                Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.magenta, 1f);
             }
             _body.Position += step * direction;
             MoveToAvoidContact(obstruction);

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -56,7 +56,7 @@ namespace PQ._Experimental.Physics.Move_006
             {
                 // any surface passed through (tunneling) for the initial separation can be prevented by moving back along normal
                 // May occur when body is heavily overlapped with an edge collider causing it 'snap' to other side
-                Debug.Log($"RemoveOverlap({collider.name}).substep#precheck : Initial resolution caused collider to pass through an edge - pushing back to compensate");
+                Debug.Log($"ResolveSeparation({collider.name}).substep#precheck : Initial resolution caused collider to pass through an edge - pushing back to compensate");
                 _body.IntersectAABB(_body.Position, separation.normal, out float distanceToAABBEdge);
                 _body.Position += -2f * distanceToAABBEdge * separation.normal;
             }
@@ -69,12 +69,12 @@ namespace PQ._Experimental.Physics.Move_006
                 Vector2 beforeStep = _body.Position;
                 separation = _body.ComputeMinimumSeparation(collider);
 
-                Debug.Log($"RemoveOverlap({collider.name}).substep#{MaxOverlapIterations - iteration} : remaining={separation.distance}, direction={separation.normal}");
+                Debug.Log($"ResolveSeparation({collider.name}).substep#{MaxOverlapIterations - iteration} : remaining={separation.distance}, direction={separation.normal}");
 
                 if (Mathf.Abs(separation.distance) > Mathf.Abs(previousSeparation.distance))
                 {
                     // Any time separation not decreasing then bail out. May occur when moving into a protruding corner causing over-correction.
-                    Debug.Log($"RemoveOverlap({collider.name}) : Separation amount increased from {previousSeparation.distance} to {separation.distance} - halting resolution");
+                    Debug.Log($"ResolveSeparation({collider.name}) : Separation amount increased from {previousSeparation.distance} to {separation.distance} - halting resolution");
                     break;
                 }
                 _body.Position += separation.distance * separation.normal;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -200,15 +200,16 @@ namespace PQ._Experimental.Physics.Move_006
                 Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.magenta, 1f);
             }
 
-            float bodyRadius = _body.ComputeDistanceToEdge(direction);
-            if (_body.CastRay(_body.Position, direction, bodyRadius + ContactOffset, out RaycastHit2D rayHit) &&
+            Vector2 directionToHit = (closestHit.point - _body.Position).normalized;
+            float bodyRadius = _body.ComputeDistanceToEdge(directionToHit);
+            if (_body.CastRay(_body.Position, directionToHit, bodyRadius + ContactOffset, out RaycastHit2D rayHit) &&
                 (rayHit.distance - bodyRadius) < ContactOffset)
             {
                 obstruction = rayHit;
                 float contactOffsetCorrection = rayHit.distance - bodyRadius;
                 Debug.Log($"contactOffsetCorrection={contactOffsetCorrection}");
-                step += contactOffsetCorrection;
-                _body.Position -= contactOffsetCorrection * direction;
+
+                DebugExtensions.DrawArrow(rayHit.point, rayHit.point + ContactOffset * rayHit.normal, Color.magenta, 1f);
             }
             _body.Position += step * direction;
         }

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -217,7 +217,7 @@ namespace PQ._Experimental.Physics.Move_006
             normalizedHit.normal   = -direction;
             normalizedHit.centroid = Vector2.LerpUnclamped(hitA.centroid, hitC.centroid, 0.50f);
 
-            Debug.DrawLine(hitA.point, hitB.point, Color.black, 1f);
+            Debug.DrawLine(hitA.point, hitC.point, Color.black, 1f);
             Debug.DrawLine(normalizedHit.centroid, normalizedHit.point, Color.blue, 1f);
             return true;
         }

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/KinematicLinearSolver2D.cs
@@ -191,6 +191,7 @@ namespace PQ._Experimental.Physics.Move_006
                 step = Mathf.Max(closestHit.distance - ContactOffset, 0f);
                 obstruction = closestHit;
                 Debug.DrawLine(_body.Position, _body.Position + step * direction, Color.cyan, 1f);
+                DebugExtensions.DrawPlus(closestHit.point, new Vector2(ContactOffset, ContactOffset), 45f, Color.yellow, 1f);
             }
             else
             {
@@ -200,11 +201,11 @@ namespace PQ._Experimental.Physics.Move_006
             }
 
             float bodyRadius = _body.ComputeDistanceToEdge(direction);
-            if (_body.CastRay(_body.Position, direction, bodyRadius + ContactOffset, out RaycastHit2D circleHit) &&
-                (circleHit.distance - bodyRadius) < ContactOffset)
+            if (_body.CastRay(_body.Position, direction, bodyRadius + ContactOffset, out RaycastHit2D rayHit) &&
+                (rayHit.distance - bodyRadius) < ContactOffset)
             {
-                obstruction = circleHit;
-                float contactOffsetCorrection = circleHit.distance - bodyRadius;
+                obstruction = rayHit;
+                float contactOffsetCorrection = rayHit.distance - bodyRadius;
                 Debug.Log($"contactOffsetCorrection={contactOffsetCorrection}");
                 step += contactOffsetCorrection;
                 _body.Position -= contactOffsetCorrection * direction;

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -215,11 +215,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.05
+      value: 4.25
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.455
+      value: 6.35
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z
@@ -289,48 +289,52 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
+      propertyPath: m_Creator
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.size
       value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[1].x
-      value: -3
+      value: -2.9714477
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[1].y
-      value: 1
+      value: 0.9785862
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[2].x
-      value: -2.2321877
+      value: -2.2136862
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[2].y
-      value: 0.6843923
+      value: 0.6705162
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[3].x
-      value: -1.4882812
+      value: -1.478231
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[3].y
-      value: 0.40658832
+      value: 0.39905065
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[4].x
-      value: -0.95672464
+      value: -0.9517164
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[4].y
-      value: 0.22977109
+      value: 0.22601496
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[5].x
-      value: -0.44641796
+      value: -0.44503054
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[5].y
-      value: 0.086557314
+      value: 0.085516766
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[7].x
@@ -382,15 +386,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[13].x
-      value: 4.4757037
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[13].y
-      value: -0.52429634
+      value: -0.5
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[14].x
-      value: 4
+      value: 4.9
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_ColliderSegment.Array.data[14].y
@@ -430,11 +434,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Spline.m_ControlPoints.Array.data[1].position.x
-      value: -3
+      value: -2.9714477
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Spline.m_ControlPoints.Array.data[1].position.y
-      value: 1
+      value: 0.97144794
       objectReference: {fileID: 0}
     - target: {fileID: 1333357489651817220, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Spline.m_ControlPoints.Array.data[2].position.x
@@ -546,7 +550,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6981010155519417703, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_LocalAABB.m_Center.y
-      value: -0.00000011920929
+      value: -0.014276087
       objectReference: {fileID: 0}
     - target: {fileID: 6981010155519417703, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_LocalAABB.m_Extent.x
@@ -554,7 +558,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6981010155519417703, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_LocalAABB.m_Extent.y
-      value: 1
+      value: 0.98572403
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_EdgeRadius
@@ -566,43 +570,43 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[1].x
-      value: -3
+      value: -2.9714477
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[1].y
-      value: 1
+      value: 0.97144794
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[2].x
-      value: -2.2321877
+      value: -2.2136862
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[2].y
-      value: 0.6843923
+      value: 0.6658906
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[3].x
-      value: -1.4882812
+      value: -1.478231
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[3].y
-      value: 0.40658832
+      value: 0.39653796
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[4].x
-      value: -0.95672464
+      value: -0.9517164
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[4].y
-      value: 0.22977109
+      value: 0.22476286
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[5].x
-      value: -0.44641796
+      value: -0.44503054
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[5].y
-      value: 0.086557314
+      value: 0.0851699
       objectReference: {fileID: 0}
     - target: {fileID: 7358749131327659747, guid: 259b98c131d92cd49b03930a4f27a834, type: 3}
       propertyPath: m_Points.Array.data[7].x

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -215,11 +215,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.25
+      value: 18.08475
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.35
+      value: 3.645856
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z
@@ -227,7 +227,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalRotation.x
@@ -235,7 +235,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalRotation.z

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -215,11 +215,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 18.08475
+      value: 1.0149343
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.645856
+      value: 9.487248
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -215,11 +215,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.0149343
+      value: 1.0458724
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 9.487248
+      value: 9.421825
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalPosition.z
@@ -227,7 +227,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.00000004371139
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalRotation.x
@@ -235,7 +235,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -1
       objectReference: {fileID: 0}
     - target: {fileID: 7577363344085367854, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       propertyPath: m_LocalRotation.z
@@ -278,6 +278,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f159713e006ed479097819c3271024, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _drawAllCastsFromBody: 0
   _timeScale: 1
   _moveSpeed: 5
 --- !u!1001 &1291089329

--- a/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Move_006__SurfaceSlidingConcaveHandling/_Move_006__SurfaceSlidingConcaveHandling.unity
@@ -278,9 +278,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 50f159713e006ed479097819c3271024, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _drawAllCastsFromBody: 0
   _timeScale: 1
   _moveSpeed: 5
+  _drawAllCastsFromBody: 0
 --- !u!1001 &1291089329
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Makes the below impossible, and the logs below that unlikely.
Technically doesn't 'bail on movement' (this still could be something done in future) - but instead makes that not needed, at least for now.

Also did some much needed cleanup/rework.

![corner catch](https://github.com/jeffreypersons/Penguin-Quest/assets/8084757/6c98e7fc-f7fb-4ed9-8f33-bee3ded982cd)

![excessive iterations](https://github.com/jeffreypersons/Penguin-Quest/assets/8084757/6feee7c1-8abe-4a04-ac4b-889cd921444e)
