### PR TITLE
[Physics] Test Scene - Account for corner checks using box casts

### DIFF
--- a/Assets/_Experimental/Sandbox_Physics/Contact_005__CastAllSides/Body.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Contact_005__CastAllSides/Body.cs
@@ -36,6 +36,7 @@ namespace PQ._Experimental.Physics.Contact_005
 
         private const float DefaultEpsilon = 0.005f;
         private const int DefaultBufferSize = 16;
+        private readonly Vector2 NormalizedDiagonal = Vector2.one.normalized;
 
         public bool IsFlippedHorizontal => _rigidbody.transform.localEulerAngles.y >= 90f;
         public bool IsFlippedVertical   => _rigidbody.transform.localEulerAngles.x >= 90f;
@@ -135,6 +136,23 @@ namespace PQ._Experimental.Physics.Contact_005
                 flags |= ContactFlags2D.BottomSide;
             }
 
+            if (CastAABB(new Vector2(1, -1) * NormalizedDiagonal, skinWidth, out _))
+            {
+                flags |= ContactFlags2D.BottomRightCorner;
+            }
+            if (CastAABB(new Vector2(1, 1) * NormalizedDiagonal, skinWidth, out _))
+            {
+                flags |= ContactFlags2D.TopRightCorner;
+            }
+            if (CastAABB(new Vector2(-1, 1) * NormalizedDiagonal, skinWidth, out _))
+            {
+                flags |= ContactFlags2D.TopLeftCorner;
+            }
+            if (CastAABB(new Vector2(-1, -1) * NormalizedDiagonal, skinWidth, out _))
+            {
+                flags |= ContactFlags2D.BottomLeftCorner;
+            }
+            
             #if UNITY_EDITOR
             Bounds bounds = _boxCollider.bounds;
             Vector2 center    = new Vector2(bounds.center.x, bounds.center.y);

--- a/Assets/_Experimental/Sandbox_Physics/Contact_005__CastAllSides/Controller.cs
+++ b/Assets/_Experimental/Sandbox_Physics/Contact_005__CastAllSides/Controller.cs
@@ -6,6 +6,7 @@ namespace PQ._Experimental.Physics.Contact_005
     public class Controller : MonoBehaviour
     {
         [SerializeField] private Body _body;
+        [SerializeField] [Range(0f, 1f)] private float _contactOffset = 0.05f;
 
         private ContactFlags2D _flags;
 
@@ -18,15 +19,7 @@ namespace PQ._Experimental.Physics.Contact_005
 
         void FixedUpdate()
         {
-            _flags = _body.CheckSides();
-            if (_body.IsCenterBoundedByAnEdgeCollider(out var collider))
-            {
-                Debug.Log($"isBoundedByEdge={collider.name}");
-            }
-            else
-            {
-                Debug.Log($"isBoundedByEdge=<none>");
-            }
+            _flags = _body.CheckForOverlappingContacts(skinWidth: _contactOffset);
         }
 
         void OnDrawGizmos()

--- a/Assets/_Experimental/Sandbox_Physics/Contact_005__CastAllSides/_Contact_005__CastAllSides.unity
+++ b/Assets/_Experimental/Sandbox_Physics/Contact_005__CastAllSides/_Contact_005__CastAllSides.unity
@@ -2120,14 +2120,14 @@ PrefabInstance:
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 5726160129927588184, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
       insertIndex: -1
-      addedObject: {fileID: 732108736}
+      addedObject: {fileID: 732108741}
   m_SourcePrefab: {fileID: 100100000, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
 --- !u!1 &732108735 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5726160129927588184, guid: be9aff82aa4f8834c8d78905c9b7065a, type: 3}
   m_PrefabInstance: {fileID: 732108734}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &732108736
+--- !u!114 &732108741
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2136,9 +2136,10 @@ MonoBehaviour:
   m_GameObject: {fileID: 732108735}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e4df8e18532b1e94e9750de2a3b5df2d, type: 3}
+  m_Script: {fileID: 11500000, guid: 16df7474cd8574d4e931060ccec3cc0f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _contactOffset: 0.05
 --- !u!1001 &785666190
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/_Experimental/Sandbox_Physics/DebugExtensions.cs
+++ b/Assets/_Experimental/Sandbox_Physics/DebugExtensions.cs
@@ -6,6 +6,38 @@ namespace PQ._Experimental.Physics
 {
     public static class DebugExtensions
     {
+        private struct OrientedRect
+        {
+            public readonly Vector2 Center;
+            public readonly Vector2 P0;
+            public readonly Vector2 P1;
+            public readonly Vector2 P2;
+            public readonly Vector2 P3;
+            
+            public OrientedRect(Vector2 center, Vector2 extents, float degrees)
+            {
+                float cosTheta = Mathf.Cos(Mathf.Deg2Rad * degrees);
+                float sinTheta = Mathf.Sin(Mathf.Deg2Rad * degrees);
+                
+                Vector2 xAxis = extents.x * new Vector2( cosTheta, sinTheta);
+                Vector2 yAxis = extents.y * new Vector2(-sinTheta, cosTheta);
+
+                Center = center;
+                P0 = center - xAxis - yAxis;
+                P1 = center - xAxis + yAxis;
+                P2 = center + xAxis + yAxis;
+                P3 = center + xAxis - yAxis;
+            }
+
+            public void Draw(Color color, float duration)
+            {
+                Debug.DrawLine(P0, P1, color, duration);
+                Debug.DrawLine(P1, P2, color, duration);
+                Debug.DrawLine(P2, P3, color, duration);
+                Debug.DrawLine(P3, P0, color, duration);
+            }
+        }
+
         public static Color LineColor          { get; set; } = Color.white;
         public static Color CastMissColor      { get; set; } = Color.red;
         public static Color CastHitColor       { get; set; } = Color.green;
@@ -77,6 +109,33 @@ namespace PQ._Experimental.Physics
             if (hit)
             {
                 Debug.DrawLine(origin, hit.point, CastHitColor, duration);
+            }
+        }
+
+        
+        /* Visualize the 'path' formed by dragging a box from start along given delta. */
+        public static void DrawBoxCast(Vector2 origin, Vector2 extents, float degrees, Vector2 direction, float distance, ReadOnlySpan<RaycastHit2D> hits, float duration=0f)
+        {
+            OrientedRect original = new(origin, extents, degrees);
+            OrientedRect shifted  = new(origin + distance * direction, extents, degrees);
+
+            // render the box center at the start and end of the casts, with lines connecting the corners
+            original.Draw(LineColor, duration);
+            shifted .Draw(LineColor, duration);
+            Debug.DrawLine(original.P0, shifted.P0, LineColor, duration);
+            Debug.DrawLine(original.P1, shifted.P1, LineColor, duration);
+            Debug.DrawLine(original.P2, shifted.P2, LineColor, duration);
+            Debug.DrawLine(original.P3, shifted.P3, LineColor, duration);
+
+            // render an 'x' at the cast origin with an arrow extending to the cast terminal
+            Vector2 plusSignExtents = ArrowheadSizeRatio * Mathf.LerpUnclamped(extents.x, extents.y, 0.50f) * Vector2.one;
+            DrawPlus(origin, plusSignExtents, 45f, LineColor, duration);
+            DrawArrow(original.Center, shifted.Center, LineColor, duration);
+
+            // render any 'hits' by coloring a line segment showing the hit point and distance
+            for (int i = 0; i < hits.Length; i++)
+            {
+                Debug.DrawLine(hits[i].point, hits[i].point + (hits[i].distance * -direction), CastHitColor, duration);
             }
         }
     }


### PR DESCRIPTION
Adds corner checks, so we are nearly at feature parity with the previous test scene's contact checks - but this time using box casts.
This way we can check for overlap distance etc during physics-sub-steps, not just in between move calls/physics steps.
![image](https://github.com/jeffreypersons/Penguin-Quest/assets/8084757/4e1fd898-9848-482e-ab5a-7b7d6e24d194)
