### PR TITLE
Fix incorrect spawn offset

### DIFF
--- a/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
+++ b/Assets/Code/Common/Physics/Internal/KinematicLinearSolver2D.cs
@@ -88,6 +88,13 @@ namespace PQ.Common.Physics.Internal
             _collisions = _body.CheckSides();
         }
 
+        /* Resolve overlaps and update collision flags at the current position. No movement or interpolation. */
+        public void Settle()
+        {
+            SnapToSurfaceIfNearOrInside();
+            _collisions = _body.CheckSides();
+        }
+
         public bool InContact(CollisionFlags2D flags)
         {
             return (_collisions & flags) == flags;

--- a/Assets/Code/Common/Physics/PhysicsBody2D.cs
+++ b/Assets/Code/Common/Physics/PhysicsBody2D.cs
@@ -163,8 +163,13 @@ namespace PQ.Common.Physics
 
         private void Start()
         {
-            // force collision detection on initial location
-            _kinematicSolver.SolveMovement(Vector2.zero);
+            Settle();
+        }
+
+        /* Resolve overlaps and detect contacts at current position, without movement or interpolation. */
+        public void Settle()
+        {
+            _kinematicSolver.Settle();
         }
 
         /* Set world transform to given point, ignoring physics. */

--- a/Assets/Code/Common/Physics/PhysicsBody2D.cs
+++ b/Assets/Code/Common/Physics/PhysicsBody2D.cs
@@ -167,7 +167,7 @@ namespace PQ.Common.Physics
         }
 
         /* Resolve overlaps and detect contacts at current position, without movement or interpolation. */
-        public void Settle()
+        private void Settle()
         {
             _kinematicSolver.Settle();
         }
@@ -237,6 +237,8 @@ namespace PQ.Common.Physics
             _skinWidth     = skinWidth;
             _aabbCornerMin = localMin;
             _aabbCornerMax = localMax;
+
+            Settle();
         }
         
 

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnBelly.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnBelly.cs
@@ -61,7 +61,6 @@ namespace PQ.Game.Entities.Penguin
         private void HandleConfigChanged()
         {
             Blob.PhysicsBody.SetAABBMinMax(Blob.Config.boundsMinProne, Blob.Config.boundsMaxProne, Blob.Config.skinWidthProne);
-            Blob.PhysicsBody.Settle();
             _grounded = Blob.PhysicsBody.IsContacting(CollisionFlags2D.Below);
         }
 

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnBelly.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnBelly.cs
@@ -60,9 +60,8 @@ namespace PQ.Game.Entities.Penguin
         
         private void HandleConfigChanged()
         {
-            // todo: after setting bounds, do overlap resolution before ground check
-            // todo: look into putting all this into the physics body class, as it's something we want to do nearly everytime bounds are changed
-            Blob.PhysicsBody.SetAABBMinMax(Blob.Config.boundsMinUpright, Blob.Config.boundsMaxUpright, Blob.Config.skinWidthUpright);
+            Blob.PhysicsBody.SetAABBMinMax(Blob.Config.boundsMinProne, Blob.Config.boundsMaxProne, Blob.Config.skinWidthProne);
+            Blob.PhysicsBody.Settle();
             _grounded = Blob.PhysicsBody.IsContacting(CollisionFlags2D.Below);
         }
 

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnFeet.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnFeet.cs
@@ -61,9 +61,8 @@ namespace PQ.Game.Entities.Penguin
 
         private void HandleConfigChanged()
         {
-            // todo: after setting bounds, do overlap resolution before ground check
-            // todo: look into putting all this into the physics body class, as it's something we want to do nearly everytime bounds are changed
             Blob.PhysicsBody.SetAABBMinMax(Blob.Config.boundsMinUpright, Blob.Config.boundsMaxUpright, Blob.Config.skinWidthUpright);
+            Blob.PhysicsBody.Settle();
             _grounded = Blob.PhysicsBody.IsContacting(CollisionFlags2D.Below);
         }
 

--- a/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnFeet.cs
+++ b/Assets/Code/Game/Entities/Penguin/States/PenguinStateOnFeet.cs
@@ -62,7 +62,6 @@ namespace PQ.Game.Entities.Penguin
         private void HandleConfigChanged()
         {
             Blob.PhysicsBody.SetAABBMinMax(Blob.Config.boundsMinUpright, Blob.Config.boundsMaxUpright, Blob.Config.skinWidthUpright);
-            Blob.PhysicsBody.Settle();
             _grounded = Blob.PhysicsBody.IsContacting(CollisionFlags2D.Below);
         }
 

--- a/Assets/Code/Game/GameController.cs
+++ b/Assets/Code/Game/GameController.cs
@@ -42,7 +42,6 @@ namespace PQ.Game
 
             _spawnSystem = new SpawnSystem();
             _playerInstance = _spawnSystem.Spawn(prefab: _playerPrefab, tag: "SpawnPoint", new SpawnCollisionOptions(SnapDirection.Down));
-            _playerInstance.GetComponent<PhysicsBody2D>().Settle();
 
             _gameEventCenter = GameEventCenter.Instance;
             _playerInstance.SetActive(true);

--- a/Assets/Code/Game/GameController.cs
+++ b/Assets/Code/Game/GameController.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using PQ.Common.Extensions;
+using PQ.Common.Physics;
 using PQ.Common.Spawning;
 using PQ.Game.Entities;
 using PQ.Game.Sound;
@@ -41,6 +42,7 @@ namespace PQ.Game
 
             _spawnSystem = new SpawnSystem();
             _playerInstance = _spawnSystem.Spawn(prefab: _playerPrefab, tag: "SpawnPoint", new SpawnCollisionOptions(SnapDirection.Down));
+            _playerInstance.GetComponent<PhysicsBody2D>().Settle();
 
             _gameEventCenter = GameEventCenter.Instance;
             _playerInstance.SetActive(true);

--- a/Assets/Code/Game/GameController.cs
+++ b/Assets/Code/Game/GameController.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using PQ.Common.Extensions;
-using PQ.Common.Physics;
 using PQ.Common.Spawning;
 using PQ.Game.Entities;
 using PQ.Game.Sound;

--- a/Assets/Prefabs/Actors/PlayerPenguin.prefab
+++ b/Assets/Prefabs/Actors/PlayerPenguin.prefab
@@ -130,15 +130,15 @@ MonoBehaviour:
   _layerMask:
     serializedVersion: 2
     m_Bits: 4096
-  _aabbCornerMin: {x: -0.22, y: -0.075}
+  _aabbCornerMin: {x: -0.22, y: 0.075}
   _aabbCornerMax: {x: 0.22, y: 1.075}
-  _skinWidth: 0.02
+  _skinWidth: 0.04
   _maxAscendableSlopeAngle: 90
   _collisionFriction: 0
   _collisionBounciness: 0
   _gravityScale: 1
   _maxSolverMoveIterations: 10
-  _maxSolverContactAdjustmentIterations: 0
+  _maxSolverContactAdjustmentIterations: 2
   _preallocatedResultBufferSize: 16
   _editorVisuals: -1
 --- !u!114 &2002890420633338778

--- a/Assets/Prefabs/Actors/PlayerPenguin.prefab
+++ b/Assets/Prefabs/Actors/PlayerPenguin.prefab
@@ -101,7 +101,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0.5}
+  m_Offset: {x: 0, y: 0.57500005}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -111,8 +111,8 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.44, y: 1.1500001}
-  m_EdgeRadius: 0.02
+  m_Size: {x: 0.44, y: 1}
+  m_EdgeRadius: 0.04
 --- !u!114 &2916047126819965676
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Fixes alignment issue on spawn in where the penguin would be offset from ground.
<img width="222" height="372" alt="pre_fix-frame1" src="https://github.com/user-attachments/assets/222976e9-a278-4186-abe3-8e5edde0eeec" /> <img width="222" height="372" alt="pre_fix-frame2" src="https://github.com/user-attachments/assets/7215bcb9-1e1e-44d7-87bd-5b11b471e7e5" />

Now we ensure the offsets are kept in sync:
<img width="444" height="744" alt="after-fix-all-frames" src="https://github.com/user-attachments/assets/5ed3c503-c14b-4854-9a32-bbd297a2e605" />
